### PR TITLE
Updating default endpoint for OTLP endpoint to use http://. OTLP cons…

### DIFF
--- a/src/hypertrace/agent/config/default.py
+++ b/src/hypertrace/agent/config/default.py
@@ -5,7 +5,7 @@ DEFAULT_AGENT_CONFIG = {
     'propagation_formats': ['TRACECONTEXT'],
     'service_name': 'pythonagent',
     'reporting': {
-        'endpoint': 'localhost:4317',
+        'endpoint': 'http://localhost:4317',
         'secure': False,
         'trace_reporter_type': 'OTLP',
         'token': '',

--- a/src/hypertrace/agent/init/__init__.py
+++ b/src/hypertrace/agent/init/__init__.py
@@ -313,7 +313,8 @@ class AgentInit:  # pylint: disable=R0902,R0903
         '''Initialize OTLP exporter'''
         try:
             otlp_exporter = OTLPSpanExporter(endpoint=self._config.agent_config.reporting.endpoint,
-                                             insecure= not self._config.agent_config.reporting.secure)
+                                             insecure= \
+                                               not self._config.agent_config.reporting.secure)
             span_processor = BatchSpanProcessor(otlp_exporter)
             self._tracer_provider.add_span_processor(span_processor)
 

--- a/src/hypertrace/agent/init/__init__.py
+++ b/src/hypertrace/agent/init/__init__.py
@@ -313,7 +313,7 @@ class AgentInit:  # pylint: disable=R0902,R0903
         '''Initialize OTLP exporter'''
         try:
             otlp_exporter = OTLPSpanExporter(endpoint=self._config.agent_config.reporting.endpoint,
-                                             insecure=self._config.agent_config.reporting.secure)
+                                             insecure= not self._config.agent_config.reporting.secure)
             span_processor = BatchSpanProcessor(otlp_exporter)
             self._tracer_provider.add_span_processor(span_processor)
 


### PR DESCRIPTION
…tructor takes insecure parameter; config file uses secure attribute-- 'not' logical operator needed.

## Description
* Updates to make OTLP exporter work with default configuration.

### Testing
* Standard pipeline ran.
* 
### Documentation
* Generated documentation has not changed.