### PR TITLE
chore(grpc): avoids exceptions when emptry trailing metadata in server.

### DIFF
--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -207,7 +207,8 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
                                  str(context.get_trailing_metadata()))
                     trailing_metadata = context.get_trailing_metadata()
                     if len(trailing_metadata) > 0:
-                        self._gisw.generic_rpc_response_handler(trailing_metadata[0], response, span)
+                        self._gisw.generic_rpc_response_handler(
+                            trailing_metadata[0], response, span)
 
                     return response
                 except Exception as error: # pylint: disable=W0703

--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -205,8 +205,10 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
                     logger.debug('Response Body: %s', str(response))
                     logger.debug('Response Headers: %s',
                                  str(context.get_trailing_metadata()))
-                    self._gisw.generic_rpc_response_handler(
-                        context.get_trailing_metadata()[0], response, span)
+                    trailing_metadata = context.get_trailing_metadata()
+                    if len(trailing_metadata) > 0:
+                        self._gisw.generic_rpc_response_handler(trailing_metadata[0], response, span)
+
                     return response
                 except Exception as error: # pylint: disable=W0703
                     # Bare exceptions are likely to be gRPC aborts, which


### PR DESCRIPTION
## Description

```
exception.escaped: False

exception.type: IndexError

exception.message: tuple index out of range

message: exception

exception.stacktrace: Traceback (most recent call last): File "/usr/local/lib/python3.7/site-packages/hypertrace/agent/instrumentation/grpc/__init__.py", line 209, in telemetry_interceptor context.get_trailing_metadata()[0], response, span) IndexError: tuple index out of range
```