### PR TITLE
pipeline adjustments to unblock changes

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8.9", "3.9"]
 
     steps:
       - name: Run apt-get update
@@ -30,25 +30,18 @@ jobs:
       - name: Install Make
         run: sudo apt-get install make
 
-      - name: Install Python
-        run: |
-          which python
-          sudo apt install software-properties-common
-          sudo add-apt-repository ppa:deadsnakes/ppa -y
-          sudo apt-get install python${{ matrix.python-version }}
-          sudo apt-get install python3-all
-          python --version
-
-      - name: Install pip
-        run: sudo apt-get install python3-pip
-
-      - name: Install pip build
-        run: python3 -m pip install --upgrade build
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - uses: actions/checkout@v2
 
-      - name: Install tox
-        run: pip install --user -r dev-requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          pip install -r requirements.txt -r dev-requirements.txt
 
       - name: Lint files
         run: make lint
@@ -61,13 +54,11 @@ jobs:
           pip install --upgrade --no-input pip
           pip install --upgrade --no-input protobuf
 
-      # while pytest-asyncio is listed in the integration tests deps, we see this missing when
-      # running the test, hence we force the install.
-      - name: Force install pytest-asyncio
-        run: sudo pip install pytest-asyncio flask mysql-connector-python==8.0.23 psycopg2-binary==2.8.6 pytest-postgresql==3.1.1 aiohttp==3.7.4
-
       - name: Run tests
-        run: PYTHON_VERSION=${{ matrix.python-version }} make test
+        run:
+          VERSION=$(${{ matrix.python-version }} | cut -c1-3)
+          echo "Version ${VERSION}"
+          PYTHON_VERSION=${VERSION} make test
 
       - name: Build package
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Python
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
         run: |
-          sudo apt install software-properties-common &&
-          sudo add-apt-repository ppa:deadsnakes/ppa -y &&
-          sudo apt-get install python3.9
-          python --version
-
-      - name: Install pip
-        run: sudo apt-get install python3-pip
-
-      - name: Install pip build
-        run: python3 -m pip install --upgrade build
+          python -m pip install --upgrade pip
+          pip install build
+          pip install -r requirements.txt
 
       - name: Install protobuf compiler
         run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,3 +19,4 @@ protobuf>=3.15.8
 tox>=3.23.0
 pylint==2.8.2
 pdoc3>=0.9.2
+flask

--- a/src/hypertrace/agent/config/environment_test.py
+++ b/src/hypertrace/agent/config/environment_test.py
@@ -47,7 +47,6 @@ def test_env_config() -> None:
     assert 'TRACECONTEXT' in config['propagation_formats']
     assert config['enabled'] is False
     assert config['_use_console_span_exporter']
-
     unset_env_variables()
 
 

--- a/tests/aiohttp/requirements.txt
+++ b/tests/aiohttp/requirements.txt
@@ -6,3 +6,4 @@ flask
 pytest
 pytest-xdist
 pytest-asyncio
+aiohttp


### PR DESCRIPTION
## Description
Pipeline failure on code from main - it looks like this has something to do with python 3.8.10 on ubuntu in the postgres test, I tested locally with 3.8.10 and couldn't reproduce(the test passed) - the last successful run on main used 3.8.5. 

This updates some of the pipeline steps to allow us to specify a patch specific python version as well as moves some of the `sudo` installed dependencies into their associated requirements.txt file.

I had to update it to use the github action for python instead of apt-get install because we can't specify a patch specific version

The goal here is to unblock other changes, not necessarily fix the root issue.
