### PR TITLE
Add handling for direct_passthrough resp body with file

### DIFF
--- a/src/hypertrace/agent/instrumentation/flask/__init__.py
+++ b/src/hypertrace/agent/instrumentation/flask/__init__.py
@@ -98,8 +98,12 @@ def _hypertrace_after_request(flask_wrapper) -> flask.wrappers.Response:
             span = flask.request.environ.get(_ENVIRON_SPAN_KEY)
             # Pull response headers
             response_headers = response.headers
-            # Pull message body
-            response_body = response.data
+
+            response_body = ""
+            # dont extract response content if body is a file
+            if not response.direct_passthrough:
+                response_body = response.data
+
             logger.debug('Span: %s', str(span))
             logger.debug('Response Headers: %s', str(response_headers))
             logger.debug('Response Body: %s', str(response_body))

--- a/tests/flask/test_flask_11.py
+++ b/tests/flask/test_flask_11.py
@@ -1,0 +1,154 @@
+import sys
+import os
+import logging
+import flask
+import pytest
+import traceback
+import json
+
+from opentelemetry.trace import Span
+from werkzeug.serving import make_server
+from flask import request
+import time
+import atexit
+import threading
+from flask import Flask, send_file
+# from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider, export
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+from hypertrace.agent import Agent
+from hypertrace.agent.filter import Filter
+from hypertrace.agent.filter.registry import Registry
+
+def setup_custom_logger(name):
+    try:
+        formatter = logging.Formatter(fmt='%(asctime)s %(levelname)-8s %(message)s',
+                                      datefmt='%Y-%m-%d %H:%M:%S')
+        handler = logging.FileHandler('agent.log', mode='a')
+        handler.setFormatter(formatter)
+        screen_handler = logging.StreamHandler(stream=sys.stdout)
+        screen_handler.setFormatter(formatter)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+        logger.addHandler(screen_handler)
+        return logger
+    except:
+        print('Failed to customize logger: exception=%s, stacktrace=%s',
+              sys.exc_info()[0],
+              traceback.format_exc())
+
+
+# Run the flask web server in a separate thread
+class FlaskServer(threading.Thread):
+    def __init__(self, app):
+        super().__init__()
+        self.daemon = True
+        threading.Thread.__init__(self)
+        self.srv = make_server('localhost', 5000, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self):
+        logger.info('starting server.')
+        self.srv.serve_forever()
+        self.start()
+
+    def shutdown(self):
+        logger.info('Shutting down server.')
+        self.srv.shutdown()
+
+
+# @pytest.mark.serial
+def test_run():
+    logger = setup_custom_logger(__name__)
+    logger.info('Initializing flask app.')
+    # Create Flask app
+    app = Flask(__name__)
+
+    @app.before_first_request
+    def before_first_request():
+        logger.debug("test_program: before_first_request() called")
+
+    @app.before_request
+    def before_request():
+        logger.debug("test_progam: before_request() called")
+
+    @app.after_request
+    def after_request(response):
+        logger.debug("test_program: after_request() called")
+        return response
+
+    @app.route("/route1")
+    def testAPI1():
+        logger.info('Serving request for /route1.')
+        return send_file("./tox.ini")
+
+    @app.route("/terminate")
+    def terminate():
+        logger.info('Serving request for /terminatae.')
+        shutdown_server()
+        response = flask.Response()
+        response.data = {'a': 'a', 'xyz': 'xyz'}
+        return response
+
+    logger.info('Flask app initialized.')
+
+    #
+    # Code snippet here represents the current initialization logic
+    #
+    logger.info('Initializing agent.')
+    agent = Agent()
+
+    agent.register_flask_app(app)
+    #
+    # End initialization logic for Python Agent
+    #
+    logger.info('Agent initialized.')
+
+    server = FlaskServer(app)
+
+    # Setup In-Memory Span Exporter
+    logger.info('Agent initialized.')
+    logger.info('Adding in-memory span exporter.')
+    memoryExporter = InMemorySpanExporter()
+    simpleExportSpanProcessor = SimpleSpanProcessor(memoryExporter)
+    agent.register_processor(simpleExportSpanProcessor)
+    logger.info('Added in-memory span exporter')
+
+    logger.info('Running test calls.')
+    with app.test_client() as c:
+        try:
+            logger.info('Making test call to /route1')
+            r1 = app.test_client().get('http://localhost:5000/route1',
+                                       headers={'tester1': 'tester1', 'tester2': 'tester2'})
+
+            assert r1.status_code == 200
+            span_list = memoryExporter.get_finished_spans()
+            assert span_list
+            assert len(span_list) == 1
+            flaskSpanAsObject = json.loads(span_list[0].to_json())
+
+            # Check that the expected results are in the flask extended span attributes
+            assert flaskSpanAsObject['attributes']['http.method'] == 'GET'
+            assert flaskSpanAsObject['attributes']['http.target'] == '/route1'
+            assert flaskSpanAsObject['attributes']['http.status_code'] == 200
+            body_message = ""
+            try:
+                 body_message = flaskSpanAsObject['attributes']['http.response.body']
+            except KeyError:
+                body_message = "key does not exist"
+                print("key does not exist")
+
+            assert body_message == "key does not exist"
+
+            memoryExporter.clear()
+
+            return 0
+        except:
+            logger.error('Failed to initialize flask instrumentation wrapper: exception=%s, stacktrace=%s',
+                         sys.exc_info()[0],
+                         traceback.format_exc())
+            raise sys.exc_info()[0]

--- a/tests/flask/tox.ini
+++ b/tests/flask/tox.ini
@@ -33,5 +33,6 @@ commands =
     pytest -rPx test_flask_6.py
     pytest -rPx test_flask_8.py
     pytest -rPx test_flask_10.py
+    pytest -rPx test_flask_11.py
 
 recreate = True


### PR DESCRIPTION
## Description
If a user attempts to return a response with a file, reading body will error because of this werkzeug logic:
https://github.com/pallets/werkzeug/blob/f7b53ee8a81f015c6c85659959004328237a3c8c/src/werkzeug/wrappers/response.py#L348-L371

(specifically the `direct_passthrough` exception at the above link)

Rather than attempting to read it and log an error just skip if direct_passthrough is set.


### Testing
Recreated in local flask app: 
```
@app.route('/')
def hello_world():
    return send_file("./app.py")
```

Which will produce this exception:
```
ERROR:hypertrace.agent.instrumentation.flask:An error occurred in flask after_request handler: exception=Attempted implicit sequence conversion but the response object is in direct passthrough mode., stacktrace=Traceback (most recent call last):
  File "/Users/User/PycharmProjects/flask-simple/venv/lib/python3.8/site-packages/hypertrace/agent/instrumentation/flask/__init__.py", line 86, in hypertrace_after_request
    response_body = response.data
  File "/Users/User/PycharmProjects/flask-simple/venv/lib/python3.8/site-packages/werkzeug/wrappers/response.py", line 309, in get_data
    self._ensure_sequence()
  File "/Users/User/PycharmProjects/flask-simple/venv/lib/python3.8/site-packages/werkzeug/wrappers/response.py", line 361, in _ensure_sequence
    raise RuntimeError(
RuntimeError: Attempted implicit sequence conversion but the response object is in direct passthrough mode.
```

Added test that uses send_file to show that we don't record the response body.


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


