### PR TITLE
Allow filter libraries to configure keys to ignore

### DIFF
--- a/src/hypertrace/agent/config/__init__.py
+++ b/src/hypertrace/agent/config/__init__.py
@@ -18,6 +18,9 @@ PYTHON_SPECIFIC_ATTRIBUTES: list = [
     '_use_console_span_exporter'
 ]
 
+# Can be used by filter libraries to extend configuration
+IGNORE_ATTRIBUTES: list = []
+
 # Initialize logger
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
@@ -66,6 +69,9 @@ class AgentConfig:  # pylint: disable=R0902,R0903
             else:
                 config_from_file = load_config_from_file(
                     os.environ['HT_CONFIG_FILE'])
+
+                for ignored_attribute in IGNORE_ATTRIBUTES:
+                    config_from_file.pop(ignored_attribute, False)
 
                 self.config = merge_config(
                     DEFAULT_AGENT_CONFIG, config_from_file)

--- a/src/hypertrace/agent/config/__init___test.py
+++ b/src/hypertrace/agent/config/__init___test.py
@@ -2,12 +2,11 @@
 import os
 
 from hypertrace.agent.config import AgentConfig
+from hypertrace.agent.config import IGNORE_ATTRIBUTES
 from . import DEFAULT_AGENT_CONFIG
 from . import merge_config
 from . import load_config_from_file
 
-
-from hypertrace.agent.config import IGNORE_ATTRIBUTES
 
 def test_merge_config() -> None:
     '''Unittest for merging config results.'''
@@ -67,8 +66,11 @@ def unset_env_variables():
         if key[0:3] == "HT_":
             del os.environ[key]
 
+
 def test_ignore_attributes_are_removed() -> None:
-    os.environ["HT_CONFIG_FILE"] = os.path.join(os.path.dirname(__file__), 'test_agent_config_ignored_keys.yaml')
+    """Test ignore keys are dropped"""
+    os.environ["HT_CONFIG_FILE"] = os.path.join(os.path.dirname(__file__),
+                                        'test_agent_config_ignored_keys.yaml')
     IGNORE_ATTRIBUTES.append("custom_key_for_filter_library")
     config = AgentConfig()
     assert not config.config.get('custom_key_for_filter_library', False)

--- a/src/hypertrace/agent/config/__init___test.py
+++ b/src/hypertrace/agent/config/__init___test.py
@@ -7,6 +7,8 @@ from . import merge_config
 from . import load_config_from_file
 
 
+from hypertrace.agent.config import IGNORE_ATTRIBUTES
+
 def test_merge_config() -> None:
     '''Unittest for merging config results.'''
     # set Environment Variable
@@ -45,7 +47,7 @@ def test_merge_config() -> None:
 def test_file_values_are_overriden_by_env() -> None:
     '''Test config is loaded from env.'''
 
-    os.environ["HT_CONFIG_FILE"] = "./src/hypertrace/agent/config/test_agent-config.yaml"
+    os.environ["HT_CONFIG_FILE"] = os.path.join(os.path.dirname(__file__), 'test_agent-config.yaml')
     os.environ["HT_REPORTING_TRACE_REPORTER_TYPE"] = "OTLP"
     os.environ["HT_SERVICE_NAME"] = "test_service"
 
@@ -64,3 +66,10 @@ def unset_env_variables():
     for key in os.environ:
         if key[0:3] == "HT_":
             del os.environ[key]
+
+def test_ignore_attributes_are_removed() -> None:
+    os.environ["HT_CONFIG_FILE"] = os.path.join(os.path.dirname(__file__), 'test_agent_config_ignored_keys.yaml')
+    IGNORE_ATTRIBUTES.append("custom_key_for_filter_library")
+    config = AgentConfig()
+    assert not config.config.get('custom_key_for_filter_library', False)
+    unset_env_variables()

--- a/src/hypertrace/agent/config/test_agent_config_ignored_keys.yaml
+++ b/src/hypertrace/agent/config/test_agent_config_ignored_keys.yaml
@@ -1,0 +1,28 @@
+service_name: pythonagent_001
+reporting:
+  endpoint: http://localhost:9411/api/v2/spans
+  secure: true
+  trace_reporter_type: ZIPKIN
+  token: "TestToken"
+  opa:
+    poll_period_seconds: 50
+    enabled: true
+data_capture:
+  http_headers:
+    request: false
+    response: false
+  http_body:
+    request: false
+    response: false
+  rpc_metadata:
+    request: false
+    response: false
+  rpc_body:
+    request: false
+    response: false
+  body_max_size_bytes: 123457
+propagation_formats: ["B3"]
+_use_console_span_exporter: true
+enabled: false
+custom_key_for_filter_library:
+  filter_library_attribute: "foo"


### PR DESCRIPTION
## Description
Libraries that use the filter API may want to add additional keys to the config file.  Currently the config will error when attempting to validate unexpected keys, this update will allow filter libraries to add keys that hypertrace can drop from it's own config.

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
