### PR TITLE
Skip config dict validation

### DIFF
--- a/src/hypertrace/agent/config/__init___test.py
+++ b/src/hypertrace/agent/config/__init___test.py
@@ -10,7 +10,7 @@ from . import load_config_from_file
 def test_merge_config() -> None:
     '''Unittest for merging config results.'''
     # set Environment Variable
-    config_file_path = "./src/hypertrace/agent/config/test_agent-config.yaml"
+    config_file_path = os.path.join(os.path.dirname(__file__), "test_agent-config.yaml")
     config_from_file = load_config_from_file(config_file_path)
 
     cfg = merge_config(
@@ -45,7 +45,7 @@ def test_merge_config() -> None:
 def test_file_values_are_overriden_by_env() -> None:
     '''Test config is loaded from env.'''
 
-    os.environ["HT_CONFIG_FILE"] = "./src/hypertrace/agent/config/test_agent-config.yaml"
+    os.environ["HT_CONFIG_FILE"] = os.path.join(os.path.dirname(__file__), "test_agent-config.yaml")
     os.environ["HT_REPORTING_TRACE_REPORTER_TYPE"] = "OTLP"
     os.environ["HT_SERVICE_NAME"] = "test_service"
 

--- a/src/hypertrace/agent/config/file_test.py
+++ b/src/hypertrace/agent/config/file_test.py
@@ -1,4 +1,5 @@
 '''Tests for file module'''
+import os.path
 
 from .file import load_config_from_file
 
@@ -6,7 +7,7 @@ from .file import load_config_from_file
 def test_load_from_file() -> None:
     '''Unittest for merging config results.'''
     # set Environment Variable
-    config_file_path = "./src/hypertrace/agent/config/test_agent-config.yaml"
+    config_file_path = os.path.join(os.path.dirname(__file__), 'test_agent-config.yaml')
     config_from_file = load_config_from_file(config_file_path)
 
     cfg = config_from_file


### PR DESCRIPTION
## Description
The goal here is to remove the internal config dictionary validation to enable filter libraries to add additional key values that hypertrace doesn't need to be aware of(or log an error because of)

I attempted to migrate this to entirely use protobuf models; however, that would break existing users programatic configured agent options(such as through `agent.edit_config`)

Python specific attributes are stored in a new attribute `custom_config`, and removed before converting config dict to proto.
