### PR TITLE
Perf Improvements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -453,7 +453,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/src/hypertrace/agent/filter/__init__.py
+++ b/src/hypertrace/agent/filter/__init__.py
@@ -9,7 +9,7 @@ class Filter(ABC):
     continues it.
     """
     @abstractmethod
-    def evaluate_url_and_headers(self, span: Span, url: str, headers: tuple) -> bool:
+    def evaluate_url_and_headers(self, span: Span, url: str, headers: dict) -> bool:
         """evaluate_url_and_headers can be used to evaluate both URL and Header"""
 
     @abstractmethod
@@ -20,7 +20,7 @@ class Filter(ABC):
 class NoopFilter(Filter):
     """NoopFilter is a filter that never blocks"""
 
-    def evaluate_url_and_headers(self, span: Span, url: str, headers: tuple) -> bool:
+    def evaluate_url_and_headers(self, span: Span, url: str, headers: dict) -> bool:
         return False
 
     def evaluate_body(self, span: Span, body) -> bool:

--- a/src/hypertrace/agent/filter/registry.py
+++ b/src/hypertrace/agent/filter/registry.py
@@ -25,7 +25,7 @@ class Registry:
         instance = filter_class()
         self.filters.append(instance)
 
-    def apply_filters(self, span: Span, url: Union[str, None], headers: tuple, body) -> bool:
+    def apply_filters(self, span: Span, url: Union[str, None], headers: dict, body) -> bool:
         '''Apply all registered filters'''
         if url or headers:
             for filter_instance in self.filters:

--- a/src/hypertrace/agent/filter/test_registry.py
+++ b/src/hypertrace/agent/filter/test_registry.py
@@ -6,7 +6,7 @@ from hypertrace.agent.filter.registry import Registry
 
 class TestFilter(Filter):
     '''Example of a filter that always returns true'''
-    def evaluate_url_and_headers(self, span: Span, url: str, headers: tuple) -> bool:
+    def evaluate_url_and_headers(self, span: Span, url: str, headers: dict) -> bool:
         return True
 
     def evaluate_body(self, span: Span, body) -> bool:
@@ -23,10 +23,10 @@ def test_apply_filter_with_values_can_return_true():
     '''Assert that apply_filters will return true when a filter returns true'''
     registry = Registry()
     registry.register(TestFilter)
-    assert registry.apply_filters(NonRecordingSpan(None), 'a_url', ('key', 'v'), 'body_data')
+    assert registry.apply_filters(NonRecordingSpan(None), 'a_url', {'key': 'v'}, 'body_data')
 
 def test_apply_filter_returns_false_by_default():
     '''Assert that apply_filters will return false by default'''
     registry = Registry()
     registry.register(TestFilter)
-    assert registry.apply_filters(NonRecordingSpan(None), None, tuple(), None) is False
+    assert registry.apply_filters(NonRecordingSpan(None), None, {}, None) is False

--- a/src/hypertrace/agent/instrumentation/__init__.py
+++ b/src/hypertrace/agent/instrumentation/__init__.py
@@ -91,7 +91,7 @@ class BaseInstrumentorWrapper:
     # otherwise don't capture
     def eligible_based_on_content_type(self, headers: dict):
         '''find content-type in headers'''
-        content_type = headers["content-type"]
+        content_type = headers.get("content-type")
         return content_type if content_type in self._ALLOWED_CONTENT_TYPES else None # plyint:disable=R1710
 
     def _generic_handler(self, record_headers: bool, header_prefix: str, # pylint:disable=R0913
@@ -169,10 +169,11 @@ class BaseInstrumentorWrapper:
                 return span
 
             logger.debug('Span is Recording!')
+            lowercased_headers = self.lowercase_headers(request_headers)
 
             # Log rpc metatdata if requested
             if self._process_request_headers:
-                self.add_headers_to_span(self.RPC_REQUEST_METADATA_PREFIX, span, request_headers)
+                self.add_headers_to_span(self.RPC_REQUEST_METADATA_PREFIX, span, lowercased_headers)
             # Log rpc body if requested
             if self._process_response_body:
                 request_body_str = str(request_body)

--- a/src/hypertrace/agent/instrumentation/__init__.py
+++ b/src/hypertrace/agent/instrumentation/__init__.py
@@ -8,7 +8,8 @@ import logging
 from opentelemetry.trace.span import Span
 
 # Setup logger name
-logger = logging.getLogger(__name__) # pylint: disable=C0103
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
 
 # This is a base class for all Hypertrace Instrumentation wrapper classes
 class BaseInstrumentorWrapper:
@@ -32,21 +33,7 @@ class BaseInstrumentorWrapper:
         self._process_response_headers = False
         self._process_request_body = False
         self._process_response_body = False
-        self._service_name = 'hypertrace-python-agent'
         self._max_body_size = 128 * 1024
-
-    # Dump object for troubleshooting purposes
-    def introspect(self, obj) -> None:
-        '''Dump object for troubleshooting purposes'''
-        logger.debug('Describing object.')
-        for func in [type, id, dir, vars, callable]:
-            try:
-                logger.debug("%s(%s):\t\t%s",
-                             func.__name__, self.introspect.__code__.co_varnames[0], func(obj))
-                logger.debug("%s: %s",
-                             func.__name__, inspect.getmembers(obj))
-            except Exception: # pylint: disable=W0703
-                logger.error("No data to display")
 
     # Log request headers in extended options?
     def get_process_request_headers(self) -> bool:
@@ -67,16 +54,6 @@ class BaseInstrumentorWrapper:
     def get_process_response_body(self) -> bool:
         '''Should it process response body?'''
         return self._process_response_body
-
-    # Get the configured service name
-    def get_service_name(self) -> str:
-        '''get service name'''
-        return self._service_name
-
-    # Get the max body size that can be captured
-    def get_max_body_size(self) -> int:
-        '''get the max body size.'''
-        return self._max_body_size
 
     # Set whether request headers should be put in extended span, takes a BoolValue as input
     def set_process_request_headers(self, process_request_headers) -> None:
@@ -114,218 +91,141 @@ class BaseInstrumentorWrapper:
 
     # Set max body size
     def set_body_max_size(self, max_body_size) -> None:
-        '''Set the max body size that will be captured.'''
         logger.debug('Setting self.body_max_size to %s.', max_body_size)
         self._max_body_size = max_body_size
 
-    # Generic HTTP Request Handler
-    def generic_request_handler(self, # pylint: disable=R0912
-                                request_headers: tuple,
-                                request_body,
-                                span: Span) -> Span :
-        '''Add extended request data to the span'''
-        logger.debug(
-            'Entering BaseInstrumentationWrapper.genericRequestHandler().')
-        try: # pylint: disable=R1702
-            logger.debug('span: %s', str(span))
-            # Only log if span is recording.
-            if span.is_recording():
-                logger.debug('Span is Recording!')
-            else:
-                return span
-            # Log request headers if requested
-            if self.get_process_request_headers():
-                logger.debug('Dumping Request Headers:')
-                for header in request_headers:
-                    logger.debug(str(header))
-                    span.set_attribute(
-                        self.HTTP_REQUEST_HEADER_PREFIX + header[0].lower(), header[1])
-            # Process request body if enabled
-            if self.get_process_request_body():
-                # Get content-type value
-                content_type_header_tuple = [
-                    item for item in request_headers if item[0].lower() == 'content-type']
-                logger.debug('content_type_header_tuple=%s',
-                             str(content_type_header_tuple))
-                # Does the content-type exist?
-                if len(content_type_header_tuple) > 0:
-                    logger.debug('Found content-type header.')
-                    # Does the content-type exist?
-                    if content_type_header_tuple[0][1] is not None\
-                      and content_type_header_tuple[0][1] != '':
-                        logger.debug(
-                            'Mimetype/content-type value exists. %s',
-                            content_type_header_tuple[0][1])
-                        # Is this an interesting content-type?
-                        if self.is_interesting_content_type(content_type_header_tuple[0][1]):
-                            logger.debug(
-                                'This is an interesting content-type.')
-                            request_body_str = None
-                            if isinstance(request_body, bytes):
-                                request_body_str = request_body.decode('UTF8', 'backslashreplace')
-                            else:
-                                request_body_str = request_body
+    # we need the headers lowercased multiple times
+    # just do it once upfront
+    def lowercase_headers(self, headers):
+        return {k.lower(): v for k, v in headers.items()}
 
-                            request_body_str = self.grab_first_n_bytes(request_body_str)
-                            if content_type_header_tuple[0][1] == 'application/json' \
-                              or content_type_header_tuple[0][1] == 'application/graphql':
-                                span.set_attribute(self.HTTP_REQUEST_BODY_PREFIX,\
-                                  request_body_str.replace("'", '"'))
-                            else:
-                                span.set_attribute(
-                                    self.HTTP_REQUEST_BODY_PREFIX, request_body_str)
-        except: # pylint: disable=W0702
+    def add_headers_to_span(self, prefix: str, span: Span, headers: dict):
+        for header_key, header_value in headers.items():
+            span.set_attribute(f"{prefix}{header_key}", header_value)
+
+    _ALLOWED_CONTENT_TYPES = [
+        "application/json",
+        "application/graphql",
+        'application/x-www-form-urlencoded'
+    ]
+
+    # We need the content type to do some escaping
+    # so if we return a content type, that indicates valid for capture,
+    # otherwise don't capture
+    def eligible_based_on_content_type(self, headers: dict):
+        content_type = headers["content-type"]
+        return content_type if content_type in self._ALLOWED_CONTENT_TYPES else None
+
+    def _generic_handler(self, record_headers: bool, header_prefix: str,
+                         record_body: bool, body_prefix: str,
+                         span: Span, headers: dict, body):
+        logger.debug('Entering BaseInstrumentationWrapper.generic_handler().')
+        try:  # pylint: disable=R1702
+            if not span.is_recording():
+                return span
+
+            logger.debug('Span is Recording!')
+            lowercased_headers = self.lowercase_headers(headers)
+            if record_headers:
+                self.add_headers_to_span(header_prefix, span, lowercased_headers)
+
+            if record_body:
+                content_type = self.eligible_based_on_content_type(lowercased_headers)
+                if content_type is None:
+                    return
+
+                body_str = None
+                if isinstance(body, bytes):
+                    body_str = body.decode('UTF8', 'backslashreplace')
+                else:
+                    body_str = body
+
+                request_body_str = self.grab_first_n_bytes(body_str)
+                if content_type == 'application/json' or content_type == 'application/graphql':
+                    # why do we need to do this?
+                    span.set_attribute(body_prefix, request_body_str.replace("'", '"'))
+                else:
+                    span.set_attribute(body_prefix, request_body_str)
+
+        except:  # pylint: disable=W0702
             logger.debug('An error occurred in genericRequestHandler: exception=%s, stacktrace=%s',
                          sys.exc_info()[0],
                          traceback.format_exc())
-            # Not rethrowing to avoid causing runtime errors
         finally:
-            return span # pylint: disable=W0150
+            return span  # pylint: disable=W0150
+
+    # Generic HTTP Request Handler
+    def generic_request_handler(self,  # pylint: disable=R0912
+                                request_headers: dict,
+                                request_body,
+                                span: Span) -> Span:
+        '''Add extended request data to the span'''
+        logger.debug('Entering BaseInstrumentationWrapper.genericRequestHandler().')
+        return self._generic_handler(self._process_request_headers, self.HTTP_REQUEST_HEADER_PREFIX,
+                                     self._process_request_body, self.HTTP_REQUEST_BODY_PREFIX,
+                                     span, request_headers, request_body)
 
     # Generic HTTP Response Handler
-    def generic_response_handler(self, # pylint: disable=R0912
-                                 response_headers: tuple,
+    def generic_response_handler(self,  # pylint: disable=R0912
+                                 response_headers: dict,
                                  response_body,
-                                 span: Span) -> Span: # pylint: disable=R0912
-        '''Add extended response data to span.'''
+                                 span: Span) -> Span:  # pylint: disable=R0912
         logger.debug(
             'Entering BaseInstrumentationWrapper.genericResponseHandler().')
-        try: # pylint: disable=R1702
-            logger.debug('span: %s', str(span))
-            # Only log if span is recording.
-            if span.is_recording():
-                logger.debug('Span is Recording!')
-            else:
-                return span
-            # Log response headers if requested
-            if self.get_process_response_headers():
-                logger.debug('Dumping Response Headers:')
-                for header in response_headers:
-                    logger.debug(str(header))
-                    span.set_attribute(
-                        self.HTTP_RESPONSE_HEADER_PREFIX + header[0].lower(), header[1])
-            # Process response body if enabled
-            if self.get_process_response_body():
-                logger.debug('Response Body: %s', str(response_body))
-                # Get content-type value
-                content_type_header_tuple = [
-                    item for item in response_headers if item[0].lower() == 'content-type']
-                logger.debug('content_type_header_tuple=%s',
-                             str(content_type_header_tuple))
-                # Does the content-type exist?
-                if len(content_type_header_tuple) > 0:
-                    logger.debug('Found content-type header.')
-                    # Does the content-type exist?
-                    if content_type_header_tuple[0][1] is not None\
-                      and content_type_header_tuple[0][1] != '':
-                        logger.debug(
-                            'Mimetype/content-type value exists. %s',
-                            content_type_header_tuple[0][1])
-                        # Is this an interesting content-type?
-                        if self.is_interesting_content_type(content_type_header_tuple[0][1]):
-                            logger.debug(
-                                'This is an interesting content-type.')
-                            response_body_str = None
-                            if isinstance(response_body, bytes):
-                                response_body_str = response_body.decode('UTF8', 'backslashreplace')
-                            else:
-                                response_body_str = response_body
-
-                            response_body_str = self.grab_first_n_bytes(response_body_str)
-                            # Format message body correctly
-                            if content_type_header_tuple[0][1] == 'application/json'\
-                              and content_type_header_tuple[0][1] == 'application/graphql':
-                                span.set_attribute(self.HTTP_RESPONSE_BODY_PREFIX,\
-                                  response_body_str.replace("'", '"'))
-                            else:
-                                span.set_attribute(
-                                    self.HTTP_RESPONSE_BODY_PREFIX, response_body_str)
-        except: # pylint: disable=W0702
-            logger.debug('An error occurred in genericResponseHandler: exception=%s, stacktrace=%s',
-                         sys.exc_info()[0],
-                         traceback.format_exc())
-            # Not rethrowing to avoid causing runtime errors
-        finally:
-            return span # pylint: disable=W0150
-
-    # Should this mimetype be put in the extended span?
-    def is_interesting_content_type(self, content_type: str) -> bool: # pylint: disable=R0201
-        '''Is this a content-type we want to write to the span?'''
-        logger.debug(
-            'Entering BaseInstrumentorWrapper.isInterestingContentType().')
-        try:
-            if content_type == 'application/json':
-                return True
-            if content_type == 'application/graphql':
-                return True
-            if content_type == 'application/x-www-form-urlencoded':
-                return True
-            return False
-        except: # pylint: disable=W0702
-            logger.debug("""An error occurred while inspecting content-type:
-                         exception=%s, stacktrace=%s""",
-                         sys.exc_info()[0],
-                         traceback.format_exc())
-            return False
+        return self._generic_handler(self._process_response_headers, self.HTTP_RESPONSE_HEADER_PREFIX,
+                                     self._process_response_body, self.HTTP_RESPONSE_BODY_PREFIX,
+                                     span, response_headers, response_body)
 
     # Generic RPC Request Handler
     def generic_rpc_request_handler(self,
-                                    request_headers: tuple,
+                                    request_headers: dict,
                                     request_body,
                                     span: Span) -> Span:
         '''Add extended request rpc data to span.'''
         logger.debug(
             'Entering BaseInstrumentationWrapper.genericRpcRequestHandler().')
         try:
-            logger.debug('span: %s', str(span))
             # Is the span currently recording?
-            if span.is_recording():
-                logger.debug('Span is Recording!')
-            else:
+            if not span.is_recording():
                 return span
+
+            logger.debug('Span is Recording!')
+
             # Log rpc metatdata if requested
-            if self.get_process_request_headers():
-                logger.debug('Dumping Request Headers:')
-                for header in request_headers:
-                    logger.debug(str(header))
-                    span.set_attribute(
-                        self.RPC_REQUEST_METADATA_PREFIX + header[0].lower(), header[1])
+            if self._process_request_headers:
+                self.add_headers_to_span(self.RPC_REQUEST_METADATA_PREFIX, span, request_headers)
             # Log rpc body if requested
             if self.get_process_request_body():
                 request_body_str = str(request_body)
                 request_body_str = self.grab_first_n_bytes(request_body_str)
                 span.set_attribute(self.RPC_REQUEST_BODY_PREFIX,
                                    request_body_str)
-        except: # pylint: disable=W0702
+        except:  # pylint: disable=W0702
             logger.debug('An error occurred in genericRequestHandler: exception=%s, stacktrace=%s',
                          sys.exc_info()[0],
                          traceback.format_exc())
             # Not rethrowing to avoid causing runtime errors
         finally:
-            return span # pylint: disable=W0150
+            return span  # pylint: disable=W0150
 
     # Generic RPC Response Handler
     def generic_rpc_response_handler(self,
-                                     response_headers: tuple,
+                                     response_headers: dict,
                                      response_body,
                                      span: Span) -> Span:
         '''Add extended response rpc data to span'''
         logger.debug(
             'Entering BaseInstrumentationWrapper.genericRpcResponseHandler().')
         try:
-            logger.debug('span: %s', str(span))
-            logger.debug('responseHeaders: %s', str(response_headers))
-            logger.debug('responseBody: %s', str(response_body))
             # is the span currently recording?
             if span.is_recording():
                 logger.debug('Span is Recording!')
             else:
                 return span
             # Log rpc metadata if requested?
-            if self.get_process_response_headers():
+            if self._process_response_headers:
                 logger.debug('Dumping Response Headers:')
                 for header in response_headers:
-                    logger.debug(str(header))
                     span.set_attribute(
                         self.RPC_RESPONSE_METADATA_PREFIX + header[0].lower(), header[1])
             # Log rpc body if requested
@@ -335,13 +235,13 @@ class BaseInstrumentorWrapper:
                 response_body_str = self.grab_first_n_bytes(response_body_str)
                 span.set_attribute(
                     self.RPC_RESPONSE_BODY_PREFIX, response_body_str)
-        except: # pylint: disable=W0702
+        except:  # pylint: disable=W0702
             logger.debug('An error occurred in genericResponseHandler: exception=%s, stacktrace=%s',
                          sys.exc_info()[0],
                          traceback.format_exc())
             # Not rethrowing to avoid causing runtime errors
         finally:
-            return span # pylint: disable=W0150
+            return span  # pylint: disable=W0150
 
     # Check body size
     def check_body_size(self, body: str) -> bool:
@@ -349,7 +249,7 @@ class BaseInstrumentorWrapper:
         if body in (None, ''):
             return False
         body_len = len(body)
-        max_body_size = self.get_max_body_size()
+        max_body_size = self._max_body_size
         if max_body_size and body_len > max_body_size:
             logger.debug('message body size is greater than max size.')
             return True
@@ -360,7 +260,7 @@ class BaseInstrumentorWrapper:
         '''Return the first N (max_body_size) bytes of a request'''
         if body in (None, ''):
             return ''
-        if self.check_body_size(body): # pylint: disable=R1705
-            return body[0, self.get_max_body_size()]
+        if self.check_body_size(body):  # pylint: disable=R1705
+            return body[0, self._max_body_size]
         else:
             return body

--- a/src/hypertrace/agent/instrumentation/aiohttp/__init__.py
+++ b/src/hypertrace/agent/instrumentation/aiohttp/__init__.py
@@ -116,8 +116,6 @@ def create_trace_config(
             params: aiohttp.TraceRequestEndParams,
     ) -> None:
         logger.debug('Entering hypertrace on_request_end().')
-        logger.debug('request headers: %s', str(params.headers))
-        logger.debug('response headers: %s', str(params.response.headers))
         # utf8_decoder = codecs.getincrementaldecoder('utf-8')
         response_body = b''
         if hasattr(params.response, 'content') \
@@ -151,19 +149,13 @@ def create_trace_config(
         request_body = ''
         if hasattr(trace_config_ctx, 'request_body') and trace_config_ctx.request_body is not None:
             request_body = trace_config_ctx.request_body
-            logger.debug('request_body: %s', request_body)
         span = trace.get_current_span()
-        logger.debug('Found span: %s', str(span))
         # Add headers & body to span
         if span.is_recording():
-            request_headers = [
-                (k, v) for k, v in params.headers.items()]  # pylint: disable=R1721
             aiohttp_client_wrapper.generic_request_handler(
-                request_headers, request_body, span)
-            response_headers = [(k, v)
-                                for k, v in params.response.headers.items()]  # pylint: disable=R1721
+                params.headers, request_body, span)
             aiohttp_client_wrapper.generic_response_handler(
-                response_headers, response_body, span)
+                params.response.headers, response_body, span)
         trace_config_ctx.end_callback_called = True
         trace_config_ctx.span = span
 

--- a/src/hypertrace/agent/instrumentation/flask/__init__.py
+++ b/src/hypertrace/agent/instrumentation/flask/__init__.py
@@ -59,13 +59,11 @@ def _hypertrace_before_request(flask_wrapper):
             request_headers = flask.request.headers
             # Pull message body
             request_body = flask.request.data       # same
-            logger.debug('span: %s', str(span))
 
             span.update_name(str(flask.request.method) + ' ' + str(flask.request.url_rule))
 
             # Call base request handler
-            flask_wrapper.generic_request_handler(
-                request_headers, request_body, span)
+            flask_wrapper.generic_request_handler(request_headers, request_body, span)
 
             block_result = Registry().apply_filters(span,
                                                     flask.request.url,
@@ -102,8 +100,6 @@ def _hypertrace_after_request(flask_wrapper) -> flask.wrappers.Response:
             # dont extract response content if body is a file
             if not response.direct_passthrough:
                 response_body = response.data
-
-            logger.debug('Span: %s', str(span))
 
             # Call base response handler
             flask_wrapper.generic_response_handler(

--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -148,8 +148,6 @@ class _OpenTelemetryWrapperServicerContext(_server._OpenTelemetryServicerContext
         Allows us to capture the response headers"""
         logger.debug(
             'Entering _OpenTelemetryWrapperServicerContext.set_trailing_metadata().')
-        logger.debug('Span Object: %s', str(self._active_span))
-        logger.debug('Response Headers: %s', str(args))
         self._response_headers = args
         return self._servicer_context.set_trailing_metadata(*args, **kwargs)
 
@@ -191,11 +189,8 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
                         request_or_iterator,
                         context,
                     )
-                logger.debug('Span Object: %s', str(context._active_span)) # pylint: disable=W0212
+
                 span = context._active_span # pylint: disable=W0212
-                logger.debug('Request Metadata: %s',
-                             str(handler_call_details.invocation_metadata))
-                logger.debug('Request Body: %s', str(request_or_iterator))
 
                 invocation_metadata = handler_call_details.invocation_metadata
 
@@ -214,9 +209,6 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
                     context = _OpenTelemetryWrapperServicerContext(
                         context, span)
                     response = behavior(request_or_iterator, context)
-                    logger.debug('Response Body: %s', str(response))
-                    logger.debug('Response Headers: %s',
-                                 str(context.get_trailing_metadata()))
                     trailing_metadata = context.get_trailing_metadata()
                     if len(trailing_metadata) > 0:
                         self._gisw.generic_rpc_response_handler(
@@ -261,10 +253,7 @@ class OpenTelemetryClientInterceptorWrapper(_client.OpenTelemetryClientIntercept
             'Entering OpenTelemetryClientInterceptorWrapper.intercept_unary().')
         try:
             # Not sure how to obtain span object here
-            logger.debug('request: %s', str(request))
-            logger.debug('metadata: %s', str(metadata))
             result = invoker(request, metadata)
-            logger.debug('result: %s', str(result))
             # Not sure how to obtain trailing metadata here
         except grpc.RpcError as err:
             logger.error(constants.INST_RUNTIME_EXCEPTION_MSSG,

--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -192,7 +192,7 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
 
                 span = context._active_span # pylint: disable=W0212
 
-                invocation_metadata = handler_call_details.invocation_metadata
+                invocation_metadata = dict(handler_call_details.invocation_metadata)
 
                 self._gisw.generic_rpc_request_handler(
                     invocation_metadata, request_or_iterator, span)
@@ -210,9 +210,10 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
                         context, span)
                     response = behavior(request_or_iterator, context)
                     trailing_metadata = context.get_trailing_metadata()
+                    trailing_metadata = dict(trailing_metadata[0])
                     if len(trailing_metadata) > 0:
                         self._gisw.generic_rpc_response_handler(
-                            trailing_metadata[0], response, span)
+                            trailing_metadata, response, span)
 
                     return response
                 except Exception as error: # pylint: disable=W0703
@@ -253,7 +254,7 @@ class OpenTelemetryClientInterceptorWrapper(_client.OpenTelemetryClientIntercept
             'Entering OpenTelemetryClientInterceptorWrapper.intercept_unary().')
         try:
             # Not sure how to obtain span object here
-            result = invoker(request, metadata) # pylint:disable=W0612
+            result = invoker(request, metadata)
             # Not sure how to obtain trailing metadata here
         except grpc.RpcError as err:
             logger.error(constants.INST_RUNTIME_EXCEPTION_MSSG,

--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -254,7 +254,7 @@ class OpenTelemetryClientInterceptorWrapper(_client.OpenTelemetryClientIntercept
             'Entering OpenTelemetryClientInterceptorWrapper.intercept_unary().')
         try:
             # Not sure how to obtain span object here
-            result = invoker(request, metadata)
+            result = invoker(request, metadata)  # pylint:disable=W0612
             # Not sure how to obtain trailing metadata here
         except grpc.RpcError as err:
             logger.error(constants.INST_RUNTIME_EXCEPTION_MSSG,

--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -253,7 +253,7 @@ class OpenTelemetryClientInterceptorWrapper(_client.OpenTelemetryClientIntercept
             'Entering OpenTelemetryClientInterceptorWrapper.intercept_unary().')
         try:
             # Not sure how to obtain span object here
-            result = invoker(request, metadata)
+            result = invoker(request, metadata) # pylint:disable=W0612
             # Not sure how to obtain trailing metadata here
         except grpc.RpcError as err:
             logger.error(constants.INST_RUNTIME_EXCEPTION_MSSG,

--- a/src/hypertrace/agent/instrumentation/requests/__init__.py
+++ b/src/hypertrace/agent/instrumentation/requests/__init__.py
@@ -30,12 +30,10 @@ def get_active_span_for_call_wrapper(requests_wrapper):
 
         if span.is_recording():
             logger.debug('Span is recording.')
-            request_headers = response.request.headers
-            response_headers = response.headers
             requests_wrapper.generic_request_handler(
-                request_headers, request_content, span)
+                response.request.headers, request_content, span)
             requests_wrapper.generic_response_handler(
-                response_headers, response_content, span)
+                response.headers, response_content, span)
     return get_active_span_for_call
 
 def hypertrace_name_callback(method, url) -> str:

--- a/src/hypertrace/agent/instrumentation/requests/__init__.py
+++ b/src/hypertrace/agent/instrumentation/requests/__init__.py
@@ -1,12 +1,6 @@
 '''Hypertrace wrapper around OTel instrumentation class'''
-import sys
-import os.path
 import logging
-import traceback
-import functools
-import types
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
-from requests.models import Response
 from hypertrace.agent.instrumentation import BaseInstrumentorWrapper
 
 # Initialize logger with local module name
@@ -19,7 +13,6 @@ def get_active_span_for_call_wrapper(requests_wrapper):
     def get_active_span_for_call(span, response) -> None:
         '''Hypertrace call wrapper function'''
         logger.debug('Entering get_active_span_for_request().')
-        logger.debug('span: %s', str(span))
         response_content = None
         if hasattr(response, 'content'):
             logger.debug('Converting response message body to string.')
@@ -37,9 +30,8 @@ def get_active_span_for_call_wrapper(requests_wrapper):
 
         if span.is_recording():
             logger.debug('Span is recording.')
-            request_headers = [(k, v)
-                               for k, v in response.request.headers.items()] # pylint: disable=R1721
-            response_headers = [(k, v) for k, v in response.headers.items()] #pylint: disable=R1721
+            request_headers = response.request.headers
+            response_headers = response.headers
             requests_wrapper.generic_request_handler(
                 request_headers, request_content, span)
             requests_wrapper.generic_response_handler(


### PR DESCRIPTION
## Description
The goal here is to handle some low hanging fruit to improve performance: 

1.) Less `logger.debug("some message %s", str(a_span))`
Even though the log messages dont have the stringified objects interpolated when not in debug logging the `str` cast call still occurs.
(This does get costly when doing it per req for every header + body)
 
2.) headers tuple → dict
We were adding some overhead in multiple instrumentations because we were converting a header dict to a list of tuples. Using a dict instead gives us a few benefits: 

- content type lookup can be simple key lookup, no need to iterate over all headers
- Saves us a conversions from dict to tuple


left = current released version, right = this PR
<img width="1131" alt="Screen Shot 2021-09-24 at 5 31 24 PM" src="https://user-images.githubusercontent.com/15878949/134742710-1710485b-043e-4c2c-b07a-a578fe9079b7.png">

The profiler data below has been filtered to just show hypertrace calls. 
The important detail is that this PR has lower top level ttot values than the current release:

ex: 
hypertrace_before_request 0.13 vs 0.19 

(This PR + 100 req)

```yaml
name                                  ncall  tsub      ttot      tavg      
..__.py:48 hypertrace_before_request  100    0.007830  0.139217  0.001392
..InstrumentedFlask._generic_handler  199    0.005692  0.101931  0.000512
..entedFlask.generic_request_handler  100    0.001194  0.071479  0.000715
..trumentedFlask.add_headers_to_span  199    0.002609  0.048455  0.000243
..t__.py:90 hypertrace_after_request  99     0.002903  0.047636  0.000481
..nstrumentedFlask.lowercase_headers  199    0.001573  0.035597  0.000179
..entation/__init__.py:76 <dictcomp>  199    0.004087  0.034024  0.000171
..ntedFlask.generic_response_handler  99     0.000918  0.033897  0.000342
..gent/filter/registry.py:13 __new__  100    0.004116  0.004442  0.000044
..ask.eligible_based_on_content_type  199    0.000993  0.001368  0.000007
..strumentedFlask.grab_first_n_bytes  99     0.000678  0.001348  0.000014
..eInstrumentedFlask.check_body_size  99     0.000495  0.000670  0.000007
..r/registry.py:18 Registry.__init__  100    0.000427  0.000649  0.000006
..istry.py:28 Registry.apply_filters  100    0.000317  0.000317  0.000003
```

Current released version + 100 Requests

```yaml
..__.py:48 hypertrace_before_request  100    0.009801  0.198750  0.001988
..entedFlask.generic_request_handler  100    0.014139  0.116980  0.001170
..t__.py:92 hypertrace_after_request  99     0.003852  0.074692  0.000754
..ntedFlask.generic_response_handler  99     0.009162  0.050550  0.000511
..ntation/__init__.py:146 <listcomp>  100    0.002642  0.027981  0.000280
..strumentedFlask.grab_first_n_bytes  99     0.000691  0.001951  0.000020
..eInstrumentedFlask.check_body_size  99     0.000835  0.001260  0.000013
..ntation/__init__.py:211 <listcomp>  99     0.000691  0.001061  0.000011
..dFlask.is_interesting_content_type  99     0.000480  0.001057  0.000011
..gent/filter/registry.py:13 __new__  100    0.000505  0.000754  0.000008
..r/registry.py:18 Registry.__init__  100    0.000438  0.000659  0.000007
..istry.py:28 Registry.apply_filters  100    0.000370  0.000370  0.000004
..dFlask.get_process_request_headers  100    0.000280  0.000280  0.000003
..Flask.get_process_response_headers  99     0.000270  0.000270  0.000003
..ntedFlask.get_process_request_body  100    0.000263  0.000263  0.000003
..tedFlask.get_process_response_body  99     0.000254  0.000254  0.000003
..nstrumentedFlask.get_max_body_size  99     0.000236  0.000236  0.000002
```
