### PR TITLE
GRPC resp metadata colleciton fails if tuple is empty

### DIFF
--- a/src/hypertrace/agent/instrumentation/grpc/__init__.py
+++ b/src/hypertrace/agent/instrumentation/grpc/__init__.py
@@ -210,8 +210,8 @@ class OpenTelemetryServerInterceptorWrapper(_server.OpenTelemetryServerIntercept
                         context, span)
                     response = behavior(request_or_iterator, context)
                     trailing_metadata = context.get_trailing_metadata()
-                    trailing_metadata = dict(trailing_metadata[0])
                     if len(trailing_metadata) > 0:
+                        trailing_metadata = dict(trailing_metadata[0])
                         self._gisw.generic_rpc_response_handler(
                             trailing_metadata, response, span)
 

--- a/tests/grpc/test_grpc_3.py
+++ b/tests/grpc/test_grpc_3.py
@@ -91,9 +91,6 @@ logger.info('Added in-memoy span exporter')
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
     def SayHello(self, request, context):
         logger.debug('Received request.')
-        metadata = (('tester', 'tester'), ('tester2', 'tester2'))
-        logger.debug('Setting custom headers.')
-        context.set_trailing_metadata(metadata)
         logger.debug('Returning response.')
         return helloworld_pb2.HelloReply(message='Hello, %s!' % request.name)
 


### PR DESCRIPTION
## Description
This was a result of the performance changes, if a tuple is empty and we attempt to access it we will get an index out of range

```
>>> t = tuple()
>>> t[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: tuple index out of range
```

Our `test_grpc_3` wasnt checking the trailing metadata for anything so i removed them in that test. (present trailing metadata is covered in `test_grpc_1`)

