### PR TITLE
Django - set http.status_code on filter 

### DIFF
--- a/src/hypertrace/agent/instrumentation/django/__init__.py
+++ b/src/hypertrace/agent/instrumentation/django/__init__.py
@@ -34,6 +34,9 @@ class DjangoInstrumentationWrapper(BaseInstrumentorWrapper):
                                                     body)
             if block_result:
                 logger.debug('should block evaluated to true, aborting with 403')
+                # since middleware chain is halted the status code is not set when blocked
+                span.set_attribute('http.status_code', 403)
+                span.end()
                 raise PermissionDenied
         except PermissionDenied as permission_denied:
             raise permission_denied

--- a/tests/django/test_django_1.py
+++ b/tests/django/test_django_1.py
@@ -1,6 +1,3 @@
-import sys
-import logging
-import traceback
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -62,6 +59,11 @@ def test_can_block(client):
     r.register(SampleBlockingFilter)
     response = client.post('/test/123', data={"some_client_data": "123"}, content_type="application/json")
     assert response.status_code == 403
+    simpleExportSpanProcessor.force_flush(1)
+    span_list = memoryExporter.get_finished_spans()
+    django_span = span_list[0]
+    attrs = django_span.attributes
+    assert attrs['http.status_code'] == 403
     r.filters.clear()
     memoryExporter.clear()
 


### PR DESCRIPTION
## Description

Since middleware chain is halted during a blocked request we weren't reporting the resp status code. 