### PR TITLE
Log cleanup

### DIFF
--- a/src/hypertrace/agent/config/__init__.py
+++ b/src/hypertrace/agent/config/__init__.py
@@ -67,6 +67,7 @@ class AgentConfig:  # pylint: disable=R0902,R0903
 
         # transform(to not break old support) like zipkin != proto def of ZIPKIN
         _transform_values(config_dict)
+        logger.info("Config init complete - config state: %s", config_dict)
 
         # Create Protobuf AgentConfig object
         #

--- a/src/hypertrace/agent/config/environment.py
+++ b/src/hypertrace/agent/config/environment.py
@@ -26,7 +26,7 @@ def load_config_from_env() -> dict:  # pylint: disable=R0912,R0915,R0914
 
     reporter_type = get_env_value('REPORTING_TRACE_REPORTER_TYPE')
     if reporter_type:
-        logger.info(
+        logger.debug(
             "[env] Loaded REPORTING_TRACE_REPORTER_TYPE from env")
         config['reporting']['trace_reporter_type'] = reporter_type
 

--- a/src/hypertrace/agent/init/__init__.py
+++ b/src/hypertrace/agent/init/__init__.py
@@ -149,12 +149,15 @@ class AgentInit:  # pylint: disable=R0902,R0903
         trace.get_tracer_provider().add_span_processor(simple_export_span_processor)
 
     def _init_exporter(self, trace_reporter_type):
+        exporter_type = ''
         try:
             if trace_reporter_type == config_pb2.TraceReporterType.ZIPKIN:
+                exporter_type = 'zipkin'
                 exporter = ZipkinExporter(
                     endpoint=self._config.agent_config.reporting.endpoint
                 )
             elif trace_reporter_type == config_pb2.TraceReporterType.OTLP:
+                exporter_type = 'otlp'
                 exporter = OTLPSpanExporter(endpoint=self._config.agent_config.reporting.endpoint,
                                             insecure= not self._config.agent_config.reporting.secure)
             else:
@@ -163,10 +166,11 @@ class AgentInit:  # pylint: disable=R0902,R0903
             span_processor = BatchSpanProcessor(exporter)
             trace.get_tracer_provider().add_span_processor(span_processor)
 
-            logger.info(
-                'Initialized Zipkin exporter reporting to `%s`',
-                self._config.agent_config.reporting.endpoint)
+            logger.info('Initialized %s exporter reporting to `%s`',
+                        exporter_type,
+                        self._config.agent_config.reporting.endpoint)
         except Exception as err:  # pylint: disable=W0703
-            logger.error('Failed to initialize Zipkin exporter: exception=%s, stacktrace=%s',
+            logger.error('Failed to initialize %s exporter: exception=%s, stacktrace=%s',
+                         exporter_type,
                          err,
                          traceback.format_exc())


### PR DESCRIPTION
Minor log cleanup:
 - we had one env log that was set to info, the rest were debug
 - the exporter initialization always logged zipkin
 - log the config state after env + file + defaults are done being processed at info level