### PR TITLE
Update Filter.evaluate_body to also use headers

### DIFF
--- a/src/hypertrace/agent/filter/__init__.py
+++ b/src/hypertrace/agent/filter/__init__.py
@@ -13,7 +13,7 @@ class Filter(ABC):
         """evaluate_url_and_headers can be used to evaluate both URL and Header"""
 
     @abstractmethod
-    def evaluate_body(self, span: Span, body) -> bool:
+    def evaluate_body(self, span: Span, body, headers: dict) -> bool:
         """evaluate_body can be used to evaluate the body content"""
 
 
@@ -23,5 +23,5 @@ class NoopFilter(Filter):
     def evaluate_url_and_headers(self, span: Span, url: str, headers: dict) -> bool:
         return False
 
-    def evaluate_body(self, span: Span, body) -> bool:
+    def evaluate_body(self, span: Span, body, headers: dict) -> bool:
         return False

--- a/src/hypertrace/agent/filter/registry.py
+++ b/src/hypertrace/agent/filter/registry.py
@@ -34,7 +34,7 @@ class Registry:
 
         if body:
             for filter_instance in self.filters:
-                if filter_instance.evaluate_body(span, body):
+                if filter_instance.evaluate_body(span, body, headers):
                     return True
 
         return False

--- a/src/hypertrace/agent/filter/test_registry.py
+++ b/src/hypertrace/agent/filter/test_registry.py
@@ -9,7 +9,7 @@ class TestFilter(Filter):
     def evaluate_url_and_headers(self, span: Span, url: str, headers: dict) -> bool:
         return True
 
-    def evaluate_body(self, span: Span, body) -> bool:
+    def evaluate_body(self, span: Span, body, headers: dict) -> bool:
         return True
 
 def test_register():

--- a/tests/django/test_django_1.py
+++ b/tests/django/test_django_1.py
@@ -16,7 +16,7 @@ class SampleBlockingFilter(Filter):
     def evaluate_url_and_headers(self, span: Span, url: str, headers: dict) -> bool:
         return True
 
-    def evaluate_body(self, span: Span, body) -> bool:
+    def evaluate_body(self, span: Span, body, headers: dict) -> bool:
         pass
 
 @pytest.mark.django_db

--- a/tests/flask/test_flask_10.py
+++ b/tests/flask/test_flask_10.py
@@ -28,7 +28,7 @@ class SampleBlockingFilter(Filter):
     def evaluate_url_and_headers(self, span: Span, url: str, headers: tuple) -> bool:
         return True
 
-    def evaluate_body(self, span: Span, body) -> bool:
+    def evaluate_body(self, span: Span, body, headers: dict) -> bool:
         pass
 
 

--- a/tests/grpc/test_grpc_3.py
+++ b/tests/grpc/test_grpc_3.py
@@ -39,7 +39,7 @@ class SampleBlockingFilter(Filter):
     def evaluate_url_and_headers(self, span: Span, url: str, headers: tuple) -> bool:
         return True
 
-    def evaluate_body(self, span: Span, body) -> bool:
+    def evaluate_body(self, span: Span, body, headers: dict) -> bool:
         pass
 
 


### PR DESCRIPTION
## Description
Body evaluation may need to take some headers into account(for instance, if inspecting an ip address) - this updates the Filter.evaluate_body to also receive the header dict