### PR TITLE
Improve django+gunicorn auto instr

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ This agent supports these frameworks and adds following capabilities:
 - capture SQL queries
 - tracing context propagation
 
-| Module/Framework | Description | Python Versions Tested/Supported|
+
+Hypertrace python agent supports Python 3.6+
+
+| Library | Description | Supported Library Versions|
 |------|-------------| ---------------|
-| [flask](https://flask.palletsprojects.com/en/1.1.x/api)|A micro web framework written in Python.| Python 3.6, 3.7, 3.8, 3.9|
-| [django](https://docs.djangoproject.com/)|Python web framework | Python 3.6, 3.7, 3.8, 3.9|
-| [grpc](https://grpc.github.io/grpc/python/)|Python GRPC library.| Python 3.6, 3.7, 3.8, 3.9|
-| [mysql-connector](https://dev.mysql.com/doc/connector-python/en/)| Python MySQL database client library.| Python 3.6, 3.7, 3.8, 3.9|
-| [psycopg2/postgresql](https://www.psycopg.org/docs/)|Python Postgresql database client library. | Python 3.8, 3.9|
-| [requests](https://docs.python-requests.org/en/master/)|Python HTTP client library.| Python 3.6, 3.7, 3.8, 3.9|
-| [aiohttp](https://docs.aiohttp.org/en/stable/)|Python async HTTP client library.| Python 3.6, 3.7, 3.8, 3.9|
+| [flask](https://flask.palletsprojects.com/en/1.1.x/api)|A micro web framework written in Python.| 1.\*, 2.\*|
+| [django](https://docs.djangoproject.com/)|Python web framework | 1.10+|
+| [grpc](https://grpc.github.io/grpc/python/)|Python GRPC library.| 1.27+|
+| [mysql-connector](https://dev.mysql.com/doc/connector-python/en/)| Python MySQL database client library.| 8.\*|
+| [psycopg2/postgresql](https://www.psycopg.org/docs/)|Python Postgresql database client library. | 2.7.3.1+ |
+| [requests](https://docs.python-requests.org/en/master/)|Python HTTP client library.| 2.\*|
+| [aiohttp](https://docs.aiohttp.org/en/stable/)|Python async HTTP client library.| 3.\*|
 
 ## Getting started
 

--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from deprecated import deprecated
 import opentelemetry.trace as ot
 
-from hypertrace.agent.instrumentation.django.django_auto_instrumentation_compat import add_django_auto_instr_wrappers
 from hypertrace.agent.instrumentation.instrumentation_definitions import SUPPORTED_LIBRARIES, \
     get_instrumentation_wrapper, REQUESTS_KEY, GRPC_CLIENT_KEY, DJANGO_KEY, MYSQL_KEY, GRPC_SERVER_KEY, \
     POSTGRESQL_KEY, AIOHTTP_CLIENT_KEY, FLASK_KEY
@@ -109,6 +108,8 @@ class Agent:
         # and instrument as soon as the app is retrieved(since settings have to be configured
         # before returning loaded app)
         if library_key == DJANGO_KEY and auto_instrument is True:
+            from hypertrace.agent.instrumentation.django.django_auto_instrumentation_compat import \
+                add_django_auto_instr_wrappers  # pylint: disable=C0415
             add_django_auto_instr_wrappers(self, wrapper_instance)
             return
 

--- a/src/hypertrace/agent/autoinstrumentation/sitecustomize.py
+++ b/src/hypertrace/agent/autoinstrumentation/sitecustomize.py
@@ -17,4 +17,4 @@ else:
 
 # Create Hypertrace agent
 agent = Agent()
-agent.instrument(None, skip_modules)
+agent.instrument(None, skip_modules, auto_instrument=True)

--- a/src/hypertrace/agent/instrumentation/django/django_auto_instrumentation_compat.py
+++ b/src/hypertrace/agent/instrumentation/django/django_auto_instrumentation_compat.py
@@ -1,0 +1,62 @@
+"""
+we need a post-settings configured hook for django; however that isn't available, but we can wrap
+the application getters of wsgi/asgi to run our instrumentation post app init
+"""
+import logging
+
+from hypertrace.agent.instrumentation.instrumentation_definitions import DJANGO_KEY
+
+logger = logging.getLogger(__name__)
+
+
+def add_django_auto_instr_wrappers(agent_init, instrumentation_wrapper):
+    """attempt to add wsgi/asgi wrappers if auto instrumentation is used"""
+    logger.debug('attempting to add wsgi + asgi wrappers for autoinstrumentation')
+    try:
+        add_wsgi_wrapper(agent_init, instrumentation_wrapper)
+    except:  # pylint:disable=W0702
+        logger.error('django.core.wsgi.get_wsgi_application wrapping failed, django may not be instrumented')
+
+    try:
+        add_asgi_wrapper(agent_init, instrumentation_wrapper)
+    except:  # pylint:disable=W0702
+        logger.error('django.core.asgi.get_asgi_application wrapping failed, django may not be instrumented')
+
+
+def add_wsgi_wrapper(agent_init, instrumentation_wrapper):
+    """wrap the asgi wrapper get_asgi_application fn"""
+    try:
+        from django.core import wsgi  # pylint:disable=C0415
+    except:  # pylint:disable=W0702
+        logger.error('failed to import django.core.wsgi - wsgi django app may not be instrumented')
+        return
+
+    original_get_wsgi_application = wsgi.get_wsgi_application
+    wsgi.get_wsgi_application = lambda: apply_wrapper_get_app_fn(original_get_wsgi_application, agent_init,
+                                                                 instrumentation_wrapper)
+
+
+def add_asgi_wrapper(agent_init, instrumentation_wrapper):
+    """wrap the asgi wrapper get_asgi_application fn"""
+    try:
+        from django.core import asgi  # pylint:disable=C0415
+    except:  # pylint:disable=W0702
+        logger.error('failed to import django.core.asgi - asgi django app may not be instrumented')
+        return
+
+    original_get_asgi_application = asgi.get_asgi_application
+    asgi.get_asgi_application = lambda: apply_wrapper_get_app_fn(original_get_asgi_application, agent_init,
+                                                                     instrumentation_wrapper)
+
+def apply_wrapper_get_app_fn(original_fn, agent_init, instrumentation_wrapper):
+    """wrapper function that calls original app getter and then registers django instrumentation"""
+    def ht_get_application_fn():
+        app = original_fn()
+        try:
+            agent_init.register_library(DJANGO_KEY, instrumentation_wrapper)
+        except:  # pylint:disable=W0702
+            logger.error('registering django instrumentation in wsgi/asgi patch failed '
+                         '- continuing without instrumenting django')
+        return app
+
+    return ht_get_application_fn()

--- a/tests/django/test_django_1.py
+++ b/tests/django/test_django_1.py
@@ -68,16 +68,16 @@ def test_can_block(client):
     r.filters.clear()
     memoryExporter.clear()
 
-
-def test_wsgi_is_wrapped():
+@pytest.mark.django_db
+def test_wsgi_is_wrapped(client):
     del _INSTRUMENTATION_STATE[DJANGO_KEY]
     TEST_AGENT_INSTANCE._instrument(DJANGO_KEY, auto_instrument=True)
     from django.core import wsgi
     # since we cant test that its a lambda just test that our function is included in the string signature
     assert str(wsgi.get_wsgi_application).index('add_wsgi_wrapper') > 0
 
-
-def test_asgi_is_wrapped():
+@pytest.mark.django_db
+def test_asgi_is_wrapped(client):
     del _INSTRUMENTATION_STATE[DJANGO_KEY]
     TEST_AGENT_INSTANCE._instrument(DJANGO_KEY, auto_instrument=True)
     from django.core import asgi

--- a/tests/django/test_django_1.py
+++ b/tests/django/test_django_1.py
@@ -1,4 +1,5 @@
 import pytest
+from hypertrace.agent.instrumentation.instrumentation_definitions import DJANGO_KEY, _INSTRUMENTATION_STATE
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import Span
@@ -66,5 +67,21 @@ def test_can_block(client):
     assert attrs['http.status_code'] == 403
     r.filters.clear()
     memoryExporter.clear()
+
+
+def test_wsgi_is_wrapped():
+    del _INSTRUMENTATION_STATE[DJANGO_KEY]
+    TEST_AGENT_INSTANCE._instrument(DJANGO_KEY, auto_instrument=True)
+    from django.core import wsgi
+    # since we cant test that its a lambda just test that our function is included in the string signature
+    assert str(wsgi.get_wsgi_application).index('add_wsgi_wrapper') > 0
+
+
+def test_asgi_is_wrapped():
+    del _INSTRUMENTATION_STATE[DJANGO_KEY]
+    TEST_AGENT_INSTANCE._instrument(DJANGO_KEY, auto_instrument=True)
+    from django.core import asgi
+    # since we cant test that its a lambda just test that our function is included in the string signature
+    assert str(asgi.get_asgi_application).index('add_asgi_wrapper') > 0
 
 


### PR DESCRIPTION
## Description
Running django under gunicorn breaks auto instrumentation because django settings have not been configured. 

Since django relies on `django.core.wsgi`/`django.core.asgi` .`get_asgi/wsgi_application` we can wrap those functions and register django instrumentation immediately following the app being configured.