### PR TITLE
Lambda - Fix no response dict, correct reported http.url attribute

### DIFF
--- a/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
+++ b/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
@@ -31,14 +31,14 @@ class AwsLambdaInstrumentorWrapper(AwsLambdaInstrumentor, BaseInstrumentorWrappe
         super().__init__()
 
     # We need to replace default _instrument behavior to capture request/resp data
-    def _ht_instrument(self,
+    def _ht_instrument(self,  # pylint:disable=R0915
             wrapped_module_name,
             wrapped_function_name,
             event_context_extractor: Callable[[Any], Context],
             tracer_provider: TracerProvider = None,
     ):
         wrapper_instance = self
-        def _instrumented_lambda_handler_call( # pylint:disable=R0914
+        def _instrumented_lambda_handler_call( # pylint:disable=R0914,R0915
                 call_wrapped, _instance, args, kwargs
         ):
 
@@ -90,7 +90,7 @@ class AwsLambdaInstrumentorWrapper(AwsLambdaInstrumentor, BaseInstrumentorWrappe
                     elif lambda_request_context.get('path', None):
                         span.set_attribute(SpanAttributes.HTTP_METHOD, lambda_request_context.get('httpMethod', None))
                         span.set_attribute(SpanAttributes.HTTP_SCHEME, lambda_request_context.get('protocol', None))
-                        host = headers.get('host', None) or lambda_event.get('multiValueHeaders', {}).get('Host', [None])[0]
+                        host = headers.get('host', None) or lambda_event.get('multiValueHeaders', {}).get('Host', [None])[0] # pylint:disable=C0301
                         path = lambda_request_context.get('path', '')
                         if host:
                             span.set_attribute(SpanAttributes.HTTP_URL, f'{host}{path}')

--- a/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
+++ b/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
@@ -83,8 +83,6 @@ class AwsLambdaInstrumentorWrapper(AwsLambdaInstrumentor, BaseInstrumentorWrappe
                         span.set_attribute(SpanAttributes.HTTP_SCHEME, http_context.get('protocol', None))
                         host = headers.get('host', None)
                         path = http_context.get('path', '')
-                        if host:
-                            span.set_attribute(SpanAttributes.HTTP_URL, f'{host}{path}')
                         span.set_attribute(SpanAttributes.HTTP_TARGET, path)
                         span.set_attribute(SpanAttributes.HTTP_HOST, host)
                     elif lambda_request_context.get('path', None):
@@ -92,10 +90,6 @@ class AwsLambdaInstrumentorWrapper(AwsLambdaInstrumentor, BaseInstrumentorWrappe
                         span.set_attribute(SpanAttributes.HTTP_SCHEME, lambda_request_context.get('protocol', None))
                         host = headers.get('host', None) or lambda_event.get('multiValueHeaders', {}).get('Host', [None])[0] # pylint:disable=C0301
                         path = lambda_request_context.get('path', '')
-                        if host:
-                            span.set_attribute(SpanAttributes.HTTP_URL, f'{host}{path}')
-                        span.set_attribute(SpanAttributes.HTTP_TARGET, path)
-                        span.set_attribute(SpanAttributes.HTTP_HOST, host)
                         span.set_attribute(SpanAttributes.HTTP_TARGET, path)
                         span.set_attribute(SpanAttributes.HTTP_HOST, host)
 

--- a/src/hypertrace/agent/instrumentation/flask/__init__.py
+++ b/src/hypertrace/agent/instrumentation/flask/__init__.py
@@ -151,7 +151,7 @@ class FlaskInstrumentorWrapper(FlaskInstrumentor, BaseInstrumentorWrapper):
 
     # Initialize instrumentation wrapper
     @staticmethod
-    def instrument_app(app, request_hook=None, response_hook=None, tracer_provider=None, excluded_urls=None):
+    def instrument_app(app, request_hook=None, response_hook=None, tracer_provider=None, excluded_urls=None):  # pylint:disable=W0221,W0613
         '''Initialize instrumentation'''
         logger.debug('Entering FlaskInstrumentorWrapper.instument_app().')
         try:

--- a/tests/lambda/test_lambda.py
+++ b/tests/lambda/test_lambda.py
@@ -88,7 +88,7 @@ def test_run():
         span = json.loads(span_list[0].to_json())
         # Check that the expected results are in the flask extended span attributes
         assert span['attributes']['http.method'] == 'POST'
-        assert span['attributes']['http.url'] == 'something.foo.bar/default/test-function'
+        assert span['attributes']['http.host'] == 'something.foo.bar'
         assert span['attributes']['http.target'] == '/default/test-function'
         assert span['attributes']['http.request.header.x-forwarded-for'] == '202.87.208.0, 207.255.222.177'
         assert span['attributes']['http.request.header.x-amzn-trace-id'] == 'Root=1-61bc2935-0d71070e0218146e5683cd7e'

--- a/tests/lambda/test_lambda.py
+++ b/tests/lambda/test_lambda.py
@@ -88,6 +88,7 @@ def test_run():
         span = json.loads(span_list[0].to_json())
         # Check that the expected results are in the flask extended span attributes
         assert span['attributes']['http.method'] == 'POST'
+        assert span['attributes']['http.url'] == 'something.foo.bar/default/test-function'
         assert span['attributes']['http.target'] == '/default/test-function'
         assert span['attributes']['http.request.header.x-forwarded-for'] == '202.87.208.0, 207.255.222.177'
         assert span['attributes']['http.request.header.x-amzn-trace-id'] == 'Root=1-61bc2935-0d71070e0218146e5683cd7e'


### PR DESCRIPTION
## Description
- fix If a lambda is not configured to return a response dict, dont call dict methods on it(just skip response processing)
- fix - http.url attribute was previously just reporting the path, concatenate the host + path lambda fields. 