### PR TITLE
fix: handle case where we cant detect a lambda handler

### DIFF
--- a/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
+++ b/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
@@ -171,6 +171,9 @@ class AwsLambdaInstrumentorWrapper(AwsLambdaInstrumentor, BaseInstrumentorWrappe
         """
         logger.debug("in AwsLambdaInstrumentorWrapper _instrument")
         lambda_handler = os.environ.get(aws_lambda.ORIG_HANDLER, os.environ.get(aws_lambda._HANDLER))  # pylint:disable=W0212
+        if lambda_handler is None:
+            logger.debug("Lambda handler function not defined.  This is expected in non-lambda environments")
+            return
         # pylint: disable=attribute-defined-outside-init
         (
             self._wrapped_module_name,


### PR DESCRIPTION
Attempting to split the undefined lambda handler name will cause an exception. In non-lambda environments we don't expect a handler function to be defined so just early return.
