### PR TITLE
Check if on versions of python before 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
+import sys
+
 from setuptools import setup, find_packages
+
+version_tuple = sys.version_info
+# install_requires doesn't always work(like if on older versions of pip)
+if sys.version_info <= (3, 6):
+    print("Hypertrace is not supported on python versions before 3.6")
+    sys.exit(1)
 
 exec(open('src/hypertrace/version.py').read())
 
@@ -49,7 +57,7 @@ setup(
         "pyyaml",
         "protobuf>=3.15.8"
     ],
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'hypertrace-instrument = hypertrace.agent.autoinstrumentation.hypertrace_instrument:run',
         ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 version_tuple = sys.version_info
 # install_requires doesn't always work(like if on older versions of pip)
-if sys.version_info <= (3, 6):
+if sys.version_info < (3, 6):
     print("Hypertrace is not supported on python versions before 3.6")
     sys.exit(1)
 


### PR DESCRIPTION
## Description
The pip check in `python_requires` only works if on newer versions of pip.  If a user is on an old version of python, it wouldn't be surprising if they are also on an older version of pip.  In this case, print an error message and exit during install.
ex:  
```
❯ python setup.py develop
sys.version_info(major=2, minor=7, micro=16, releaselevel='final', serial=0)
Hypertrace is not supported on python versions before 3.6
```