### PR TITLE
Fast API Support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ protobuf>=3.15.8
 tox>=3.23.0
 pylint==2.8.2
 pdoc3>=0.9.2
+fastapi>=0.75.0
 flask>=1.0.1
 Django==3.2.7
 pytest-django==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ opentelemetry-instrumentation-aiohttp-client==0.27b0
 opentelemetry-instrumentation-boto==0.27b0
 opentelemetry-instrumentation-botocore==0.27b0
 opentelemetry-instrumentation-wsgi==0.27b0
+opentelemetry-instrumentation-fastapi==0.27b0
 opentelemetry-instrumentation-flask==0.27b0
 opentelemetry-instrumentation-mysql==0.27b0
 opentelemetry-instrumentation-psycopg2==0.27b0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "opentelemetry-instrumentation-boto==0.27b0",
         "opentelemetry-instrumentation-botocore==0.27b0",
         "opentelemetry-instrumentation-wsgi==0.27b0",
+        "opentelemetry-instrumentation-fastapi==0.27b0",
         "opentelemetry-instrumentation-flask==0.27b0",
         "opentelemetry-instrumentation-mysql==0.27b0",
         "opentelemetry-instrumentation-psycopg2==0.27b0",

--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -10,7 +10,7 @@ import opentelemetry.trace as ot
 
 from hypertrace.agent.instrumentation.instrumentation_definitions import SUPPORTED_LIBRARIES, \
     get_instrumentation_wrapper, REQUESTS_KEY, GRPC_CLIENT_KEY, DJANGO_KEY, MYSQL_KEY, GRPC_SERVER_KEY, \
-    POSTGRESQL_KEY, AIOHTTP_CLIENT_KEY, FLASK_KEY, LAMBDA, _uninstrument_all
+    POSTGRESQL_KEY, AIOHTTP_CLIENT_KEY, FLASK_KEY, LAMBDA,FAST_API_KEY, _uninstrument_all
 from hypertrace.env_var_settings import get_env_value
 from hypertrace.agent.init import AgentInit
 from hypertrace.agent.config import AgentConfig
@@ -112,6 +112,15 @@ class Agent:
             from hypertrace.agent.instrumentation.django.django_auto_instrumentation_compat import \
                 add_django_auto_instr_wrappers  # pylint: disable=C0415
             add_django_auto_instr_wrappers(self, wrapper_instance)
+            return
+
+        # For FastAPI we need a handle to the user app before we can instrument fast & inject middleware
+        # to make things easier for the user always add the below instrumnetation wrappers
+        # when FastAPI calls `.setup` take the app and then add instrumentation
+        if library_key == FAST_API_KEY:
+            from hypertrace.agent.instrumentation.fast_api.fast_api_auto_instrumentation_compat import \
+                add_fast_api_auto_instr_wrappers # pylint: disable=C0415
+            add_fast_api_auto_instr_wrappers(self, wrapper_instance)
             return
 
         if library_key == LAMBDA and '_HANDLER' not in os.environ:

--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -115,7 +115,7 @@ class Agent:
             return
 
         # For FastAPI we need a handle to the user app before we can instrument fast & inject middleware
-        # to make things easier for the user always add the below instrumnetation wrappers
+        # to make things easier for the user always add the below instrumentation wrappers
         # when FastAPI calls `.setup` take the app and then add instrumentation
         if library_key == FAST_API_KEY:
             from hypertrace.agent.instrumentation.fast_api.fast_api_auto_instrumentation_compat import \

--- a/src/hypertrace/agent/instrumentation/fast_api/__init__.py
+++ b/src/hypertrace/agent/instrumentation/fast_api/__init__.py
@@ -178,4 +178,5 @@ class FastAPIInstrumentorWrapper(BaseInstrumentorWrapper):
 
     def uninstrument(self):
         """Used to uninstrument fast api app"""
-        FastAPIInstrumentor.uninstrument_app(self.app)
+        if self.app:
+            FastAPIInstrumentor.uninstrument_app(self.app)

--- a/src/hypertrace/agent/instrumentation/fast_api/__init__.py
+++ b/src/hypertrace/agent/instrumentation/fast_api/__init__.py
@@ -1,0 +1,181 @@
+"""includes a middleware.__call__ wrapper and the fast api instrumentor implementation + hooks"""
+import logging
+from functools import wraps
+
+from fastapi import HTTPException
+from starlette.datastructures import Headers
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware, set_status_code
+from opentelemetry.instrumentation.asgi import get_host_port_url_tuple, \
+    context, extract, asgi_getter, trace, collect_request_attributes
+
+from hypertrace.agent.filter.registry import Registry, TYPE_HTTP
+from hypertrace.agent.instrumentation import BaseInstrumentorWrapper
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
+
+# We need to replace the entire __call__ method so that we can
+# pull the req body from the original requests receive
+async def replaced_ot_middleware_call(self, scope, receive, send): # pylint:disable=R0914
+    """The ASGI application
+
+    Args:
+        scope: A ASGI environment.
+        receive: An awaitable callable yielding dictionaries
+        send: An awaitable callable taking a single dictionary as argument.
+    """
+    if scope["type"] not in ("http", "websocket"):
+        return await self.app(scope, receive, send)
+
+    _, _, url = get_host_port_url_tuple(scope)
+    if self.excluded_urls and self.excluded_urls.url_disabled(url):
+        return await self.app(scope, receive, send)
+
+    token = context.attach(extract(scope, getter=asgi_getter))
+    span_name, additional_attributes = self.default_span_details(scope)
+
+    request = Request(scope, receive=receive)
+    body = await request.body()
+
+    try:
+        with self.tracer.start_as_current_span(
+                span_name,
+                kind=trace.SpanKind.SERVER,
+        ) as span:
+            if span.is_recording():
+                attributes = collect_request_attributes(scope)
+                attributes.update(additional_attributes)
+                for key, value in attributes.items():
+                    span.set_attribute(key, value)
+
+            should_forward_to_handler = True
+            if callable(self.server_request_hook):
+                should_forward_to_handler = self.server_request_hook(span, scope, body)
+
+            @wraps(receive)
+            async def wrapped_receive():
+                with self.tracer.start_as_current_span(
+                        " ".join((span_name, scope["type"], "receive"))
+                ) as receive_span:
+                    if callable(self.client_request_hook):
+                        self.client_request_hook(receive_span, scope)
+                    message = await receive()
+                    if receive_span.is_recording():
+                        if message["type"] == "websocket.receive":
+                            set_status_code(receive_span, 200)
+                        receive_span.set_attribute("type", message["type"])
+                return message
+
+            @wraps(send)
+            async def wrapped_send(message):
+                send_span = span
+                if callable(self.client_response_hook):
+                    self.client_response_hook(send_span, message)
+                if send_span.is_recording():
+                    if message["type"] == "http.response.start":
+                        status_code = message["status"]
+                        set_status_code(span, status_code)
+                    elif message["type"] == "websocket.send":
+                        set_status_code(span, 200)
+                    elif message["type"] == 'http.response.body':
+                        pass
+                await send(message)
+
+            if should_forward_to_handler:
+                await self.app(scope, wrapped_receive, wrapped_send)
+            else:
+                set_status_code(span, 403)
+                raise HypertraceException(status_code=403)
+    finally:
+        context.detach(token)
+
+
+OpenTelemetryMiddleware.__call__ = replaced_ot_middleware_call
+
+
+class HypertraceException(HTTPException):
+    """An exception our middleware will raise if a filter determines to block the request"""
+
+class FastAPIInstrumentorWrapper(BaseInstrumentorWrapper):
+    """Used to instrument fast api apps once an app has been loaded """
+    def __init__(self):
+        super().__init__()
+        self.app = None
+
+    def with_app(self, app):
+        """Need to defer instrumentation until we have a reference to the fast app
+        during fastapi.FastAPI.setup this is invoked and stored so that we can then instrument"""
+        self.app = app
+
+    def instrument(self):
+        """Adds our error handler as well tracing middleware"""
+        if self.app is None:
+            print("No app defined, cant instrument fast api")
+            return
+
+        async def catch_exceptions_middleware(request: Request, call_next):
+            try:
+                return await call_next(request)
+            except HypertraceException:
+                return JSONResponse(status_code=403)
+
+        # configure fast api instrumentor w hooks
+        FastAPIInstrumentor.instrument_app(app=self.app,
+                                           server_request_hook=self.server_request_hook,
+                                           client_response_hook=self.client_response_hook)
+
+        # Need to add exception middleware to the top of middleware stack
+        # if instrument_app is added after this the exceptions wont be handled by us but by default
+        # fast api handler(which results in 500 instead of 403)
+        self.app.middleware('http')(catch_exceptions_middleware)
+
+    def server_request_hook(self, span, req_data, body):
+        """this function is used to capture request attributes"""
+        span.update_name(f"{req_data['method']} {span.name}")
+        headers = dict(Headers(raw=req_data['headers']))
+        request_url = str(Request(req_data).url)
+        self.generic_request_handler(headers, body, span)
+
+        block_result = Registry().apply_filters(span,
+                                                request_url,
+                                                headers,
+                                                body,
+                                                TYPE_HTTP)
+        if block_result:
+            logger.debug('should block evaluated to true, aborting with 403')
+            return False
+        return True
+
+    def client_response_hook(self, span, resp_data):
+        """used to capture the response data
+        this function is called twice, once during each resp_phase"""
+        resp_phase = resp_data['type']
+        if resp_phase == "http.response.start":
+            status_code = resp_data["status"]
+            set_status_code(span, status_code)
+            headers = dict(Headers(raw=resp_data['headers']))
+            should_capture_body = self._capture_headers(self._process_response_headers,
+                                                        self.HTTP_RESPONSE_HEADER_PREFIX,
+                                                        span, headers, self._process_response_body)
+            span.set_attribute('hypertrace.capture', should_capture_body)
+
+        elif resp_phase == 'http.response.body':
+            should_capture = span.attributes.get('hypertrace.capture')
+            if should_capture:
+                body_data = resp_data['body']
+                body_str = None
+                if isinstance(body_data, bytes):
+                    body_str = body_data.decode('UTF8', 'backslashreplace')
+                else:
+                    body_str = body_data
+
+                resp_body_str = self.grab_first_n_bytes(body_str)
+                span.set_attribute('http.response.body', resp_body_str)
+
+    def uninstrument(self):
+        """Used to uninstrument fast api app"""
+        FastAPIInstrumentor.uninstrument_app(self.app)

--- a/src/hypertrace/agent/instrumentation/fast_api/fast_api_auto_instrumentation_compat.py
+++ b/src/hypertrace/agent/instrumentation/fast_api/fast_api_auto_instrumentation_compat.py
@@ -1,0 +1,65 @@
+"""
+we need a post-settings configured hook for django; however that isn't available, but we can wrap
+the application getters of wsgi/asgi to run our instrumentation post app init
+"""
+import logging
+
+from hypertrace.agent.instrumentation.instrumentation_definitions import FAST_API_KEY
+
+logger = logging.getLogger(__name__)
+_PATCHED_SETUP = False
+_ORIGINAL_SETUP = None
+
+def add_fast_api_auto_instr_wrappers(agent_init, instrumentation_wrapper):
+    """wrap the fast api initializer"""
+    logger.debug('attempting to add fast api initializer wrapper for autoinstrumentation')
+    try:
+        global _PATCHED_SETUP  # pylint:disable=W0603
+        if not _PATCHED_SETUP:  # pylint:disable=W0603
+            add_setup_wrapper(agent_init, instrumentation_wrapper)
+            _PATCHED_SETUP = True
+    except:  # pylint:disable=W0702
+        logger.error('django.core.wsgi.get_wsgi_application wrapping failed, django may not be instrumented')
+
+
+def add_setup_wrapper(agent_init, instrumentation_wrapper):
+    """wrap the asgi wrapper get_asgi_application fn"""
+    try:
+        import fastapi  # pylint:disable=C0415
+    except:  # pylint:disable=W0702
+        logger.error('failed to import fastapi -fastapi app may not be instrumented')
+        return
+    global _ORIGINAL_SETUP  # pylint:disable=W0603
+    _ORIGINAL_SETUP = fastapi.FastAPI.setup
+    fastapi.FastAPI.setup = lambda fastapi_app: apply_wrapper_setup_fn(_ORIGINAL_SETUP, fastapi_app,
+                                                                       agent_init,
+                                                                       instrumentation_wrapper)
+
+def unwrap():
+    """Used to unwrap the fastapi setup function"""
+    try:
+        import fastapi  # pylint:disable=C0415
+    except:  # pylint:disable=W0702
+        logger.error('failed to import fastapi -fastapi app may not be instrumented')
+        return
+    fastapi.FastAPI.setup = _ORIGINAL_SETUP
+    global _PATCHED_SETUP # pylint:disable=W0603
+    _PATCHED_SETUP = False
+
+
+def apply_wrapper_setup_fn(original_fn, fastapi_app, agent_init, instrumentation_wrapper):
+    """wrapper function that calls original app getter and then registers django instrumentation"""
+
+    # We need to run instrumentation first to inject middleware before we call the original function
+    # otherwise middleware stack changes are not applied
+    def ht_setup_fn():
+        try:
+            instrumentation_wrapper.with_app(fastapi_app)
+            agent_init.register_library(FAST_API_KEY, instrumentation_wrapper)
+        except:  # pylint:disable=W0702
+            logger.error('registering fastapi instrumentation in fastapi setup patch failed '
+                         '- continuing without instrumenting fastapi')
+        app = original_fn(fastapi_app)
+        return app
+
+    return ht_setup_fn()

--- a/src/hypertrace/agent/instrumentation/instrumentation_definitions.py
+++ b/src/hypertrace/agent/instrumentation/instrumentation_definitions.py
@@ -3,6 +3,7 @@ import logging
 
 FLASK_KEY = 'flask'
 DJANGO_KEY = 'django'
+FAST_API_KEY = 'fastapi'
 GRPC_SERVER_KEY = 'grpc:server'
 GRPC_CLIENT_KEY = 'grpc:client'
 POSTGRESQL_KEY = 'postgresql'
@@ -14,7 +15,7 @@ BOTO = 'boto'
 BOTOCORE = 'botocore'
 
 SUPPORTED_LIBRARIES = [
-    FLASK_KEY, DJANGO_KEY,
+    FLASK_KEY, DJANGO_KEY, FAST_API_KEY,
     GRPC_SERVER_KEY, GRPC_CLIENT_KEY,
     POSTGRESQL_KEY, MYSQL_KEY,
     REQUESTS_KEY, AIOHTTP_CLIENT_KEY,
@@ -55,6 +56,9 @@ def get_instrumentation_wrapper(library_key): # pylint:disable=R0912
         elif FLASK_KEY == library_key:
             from hypertrace.agent.instrumentation.flask import FlaskInstrumentorWrapper #pylint:disable=C0415
             wrapper_instance = FlaskInstrumentorWrapper()
+        elif FAST_API_KEY == library_key:
+            from hypertrace.agent.instrumentation.fast_api import FastAPIInstrumentorWrapper #pylint:disable=C0415
+            wrapper_instance = FastAPIInstrumentorWrapper()
         elif GRPC_SERVER_KEY == library_key:
             from hypertrace.agent.instrumentation.grpc import GrpcInstrumentorServerWrapper #pylint:disable=C0415
             wrapper_instance = GrpcInstrumentorServerWrapper()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,14 @@ class SampleBlockingFilter(Filter):
         pass
 
 
+class SampleBodyBlockingFilter(Filter):
+    def evaluate_url_and_headers(self, span: Span, url: str, headers: tuple, request_type) -> bool:
+        return False
+
+    def evaluate_body(self, span: Span, body, headers: dict, request_type) -> bool:
+        return True
+
+
 @pytest.fixture
 def agent():
     # we never want to export spans to default exporter
@@ -33,7 +41,13 @@ def agent():
 
 @pytest.fixture
 def agent_with_filter(agent):
-    registry = Registry().register(SampleBlockingFilter)
+    Registry().register(SampleBlockingFilter)
+    yield agent
+    Registry().filters = []
+
+@pytest.fixture
+def agent_with_body_filter(agent):
+    Registry().register(SampleBodyBlockingFilter)
     yield agent
     Registry().filters = []
 

--- a/tests/hypertrace/agent/instrumentation/fastapi/test_fastapi.py
+++ b/tests/hypertrace/agent/instrumentation/fastapi/test_fastapi.py
@@ -1,0 +1,148 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.responses import JSONResponse
+
+from hypertrace.agent.instrumentation.instrumentation_definitions import FAST_API_KEY, _INSTRUMENTATION_STATE
+from hypertrace.agent.filter.registry import Registry
+
+def create_instrumented_fast_app(agent):
+    if FAST_API_KEY in _INSTRUMENTATION_STATE:
+        del _INSTRUMENTATION_STATE[FAST_API_KEY]
+    agent._instrument(FAST_API_KEY, auto_instrument=True)
+    from fastapi import FastAPI
+    app = FastAPI()
+
+    return app
+
+
+def test_basic_span_data(agent, exporter):
+    app = create_instrumented_fast_app(agent)
+
+    @app.post("/")
+    async def read_main():
+        return {"msg": "Hello World"}
+
+    client = TestClient(app)
+
+    response = client.post("/", json={"key": "value"})
+    span_list = exporter.get_finished_spans()
+    exporter.clear()
+    assert len(span_list) == 1
+    span = span_list[0]
+
+    assert span.name == 'POST /'
+    attrs = span.attributes
+    assert attrs["http.method"] == "POST"
+    assert attrs["http.server_name"] == "testserver"
+    assert attrs["http.url"] == "http://testserver/"
+    assert attrs["http.route"] == "/"
+
+def test_capture_request_data(agent, exporter):
+    app = create_instrumented_fast_app(agent)
+
+    @app.post("/some-endpoint")
+    async def read_main():
+        return {"msg": "Hello World"}
+
+    client = TestClient(app)
+
+    response = client.post("/some-endpoint", json={"key": "value"},
+                           headers={"X-Some-Header": "some-value"})
+    span_list = exporter.get_finished_spans()
+    exporter.clear()
+    assert len(span_list) == 1
+    span = span_list[0]
+
+    assert span.name == 'POST /some-endpoint'
+    attrs = span.attributes
+    assert attrs["http.method"] == "POST"
+    assert attrs["http.server_name"] == "testserver"
+    assert attrs["http.url"] == "http://testserver/some-endpoint"
+    assert attrs["http.route"] == "/some-endpoint"
+    assert attrs["http.request.header.content-type"] == "application/json"
+    assert attrs["http.request.body"] == '{"key": "value"}'
+    assert attrs["http.request.header.x-some-header"] == "some-value"
+
+def test_capture_response_data(agent, exporter):
+    app = create_instrumented_fast_app(agent)
+
+    @app.get("/return-json")
+    async def read_main():
+        resp = JSONResponse(content={"msg": "Hello World"})
+        return resp
+
+    client = TestClient(app)
+
+    response = client.get("/return-json")
+    span_list = exporter.get_finished_spans()
+    exporter.clear()
+    assert len(span_list) == 1
+    span = span_list[0]
+
+    assert span.name == 'GET /return-json'
+    attrs = span.attributes
+    assert attrs["http.method"] == "GET"
+    assert attrs["http.server_name"] == "testserver"
+    assert attrs["http.url"] == "http://testserver/return-json"
+    assert attrs["http.route"] == "/return-json"
+    assert attrs["http.response.header.content-type"] == "application/json"
+    assert attrs["http.response.body"] == '{"msg":"Hello World"}'
+
+def test_setup_is_wrapped(agent, exporter):
+    app = create_instrumented_fast_app(agent)
+
+    @app.get("/")
+    async def read_main():
+        return {"msg": "Hello World"}
+    client = TestClient(app)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Hello World"}
+
+    # since we cant test that its a lambda just test that our function is included in the string signature
+    assert str(FastAPI.setup).index('lambda') > 0
+
+def test_headers_can_block(agent_with_filter, exporter):
+    app = create_instrumented_fast_app(agent_with_filter)
+
+    @app.get("/block")
+    async def read_main():
+        return {"msg": "Hello World"}
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/block")
+    assert response.status_code == 403
+
+    span_list = exporter.get_finished_spans()
+    exporter.clear()
+    assert len(span_list) == 1
+    span = span_list[0]
+    assert span.attributes['http.method'] == 'GET'
+    assert span.attributes['http.target'] == '/block'
+    assert span.attributes['http.status_code'] == 403
+
+def test_body_can_block(agent_with_body_filter, exporter):
+    app = create_instrumented_fast_app(agent_with_body_filter)
+
+    @app.post("/block")
+    async def read_main():
+        return {"msg": "Hello World"}
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post("/block", json={"key": "value"})
+    assert response.status_code == 403
+
+    span_list = exporter.get_finished_spans()
+    exporter.clear()
+    assert len(span_list) == 1
+    span = span_list[0]
+    assert span.attributes['http.method'] == 'POST'
+    assert span.attributes['http.target'] == '/block'
+    assert span.attributes['http.status_code'] == 403
+
+


### PR DESCRIPTION
## Description
Add fast api support

Tests check that basic span data + req data + resp data is captured.  
Tests make sure that requests can be filtered  based on headers or bodies.