### PR TITLE
FastAPI Fix cache received messages

### DIFF
--- a/tests/hypertrace/agent/instrumentation/fastapi/test_fastapi.py
+++ b/tests/hypertrace/agent/instrumentation/fastapi/test_fastapi.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Body
 from fastapi.testclient import TestClient
 from starlette.responses import JSONResponse
 
@@ -22,9 +22,8 @@ def test_basic_span_data(agent, exporter):
     app = create_instrumented_fast_app(agent)
 
     @app.post("/")
-    async def read_main(payload):
-        data = payload.dict()
-        return {"msg": data}
+    async def read_main():
+        return {"msg": "Hello world"}
 
     client = TestClient(app)
 
@@ -45,8 +44,9 @@ def test_capture_request_data(agent, exporter):
     app = create_instrumented_fast_app(agent)
 
     @app.post("/some-endpoint")
-    async def read_main():
-        return {"msg": "Hello World"}
+    async def read_main(payload: dict = Body(...)):
+        data = payload
+        return {"msg": data}
 
     client = TestClient(app)
 
@@ -54,8 +54,8 @@ def test_capture_request_data(agent, exporter):
                            headers={"X-Some-Header": "some-value"})
     span_list = exporter.get_finished_spans()
     exporter.clear()
-    assert len(span_list) == 1
-    span = span_list[0]
+    assert len(span_list) == 2
+    span = span_list[1]
 
     assert span.name == 'POST /some-endpoint'
     attrs = span.attributes

--- a/tests/hypertrace/agent/instrumentation/fastapi/test_fastapi.py
+++ b/tests/hypertrace/agent/instrumentation/fastapi/test_fastapi.py
@@ -22,8 +22,9 @@ def test_basic_span_data(agent, exporter):
     app = create_instrumented_fast_app(agent)
 
     @app.post("/")
-    async def read_main():
-        return {"msg": "Hello World"}
+    async def read_main(payload):
+        data = payload.dict()
+        return {"msg": data}
 
     client = TestClient(app)
 


### PR DESCRIPTION
## Description
In fastapi the body can only be read once per request - using `await request.body()` causes us to consume the messages which then leads to the app hanging when the route handler tries to read the payload.

Instead, consume the body messages but cache them to return to the user handler in our wrapped_receive hook.