### PR TITLE
Defer tracer initialization

### DIFF
--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -65,9 +65,9 @@ class Agent:
         '''used to register applicable instrumentation wrappers'''
 
         try:
-            self._init = AgentInit(self._config)
+            self._init = AgentInit(self._config)  # pylint: disable = W0201
             self._initialized = True
-        except Exception as err:
+        except Exception as err:  # pylint:disable = W0703
             logger.error('Failed to initialize Agent: exception=%s, stacktrace=%s',
                          err,
                          traceback.format_exc())

--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -65,8 +65,9 @@ class Agent:
         '''used to register applicable instrumentation wrappers'''
 
         try:
-            self._init = AgentInit(self._config)  # pylint: disable = W0201
-            self._initialized = True
+            if self._initialized is not True:
+                self._init = AgentInit(self._config)  # pylint: disable = W0201
+                self._initialized = True
         except Exception as err:  # pylint:disable = W0703
             logger.error('Failed to initialize Agent: exception=%s, stacktrace=%s',
                          err,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def agent():
     _uninstrument_all()
     Agent._instance = None
     agent = Agent()
+    agent.instrument()
 
     return agent
 

--- a/tests/hypertrace/__init_test.py
+++ b/tests/hypertrace/__init_test.py
@@ -1,0 +1,26 @@
+from hypertrace.agent import Agent
+from hypertrace.agent.config import AgentConfig
+from hypertrace.agent.config import config_pb2 as hypertrace_config
+
+
+def test_edit_config():
+    agent = Agent()
+    with agent.edit_config() as config:
+        config.service_name = "some new service name"
+        config.reporting.endpoint = "http://localhost:4317"
+        config.reporting.trace_reporter_type = hypertrace_config.TraceReporterType.OTLP
+        config.propagation_formats = [hypertrace_config.PropagationFormat.B3]
+
+    assert agent._config.agent_config.reporting.trace_reporter_type \
+           is hypertrace_config.TraceReporterType.OTLP  # pylint:disable=W0212
+    assert agent._config.agent_config.propagation_formats == [
+        hypertrace_config.PropagationFormat.B3]  # pylint:disable=W0212
+    assert agent._config.agent_config.service_name == "some new service name"  # pylint:disable=W0212
+
+    err = None
+    try:
+        agent.instrument()
+    except Exception as e:
+        err = e
+
+    assert err is None

--- a/tests/hypertrace/__init_test.py
+++ b/tests/hypertrace/__init_test.py
@@ -20,7 +20,7 @@ def test_edit_config():
     err = None
     try:
         agent.instrument()
-    except Exception as e:
+    except Exception as e: # pylint: disable=W0703
         err = e
 
     assert err is None


### PR DESCRIPTION
## Description
Initing the `AgentInit` during `Agent` constructor causes a tracer provider to be registered. Although we attempt to reset this it appears it no longer works as expected.  

Instead, defer AgentInit until after all configuration has been done, that way we only init tracer provider once.