### PR TITLE
Defer tracer init until ready to instrument

### DIFF
--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -65,6 +65,8 @@ class Agent:
 
     def instrument(self, app=None, skip_libraries=None, auto_instrument=False):
         '''used to register applicable instrumentation wrappers'''
+        self._init.apply_config(self._config)
+
         if skip_libraries is None:
             skip_libraries = []
         if not self.is_initialized():
@@ -80,7 +82,6 @@ class Agent:
 
     def _instrument(self, library_key, app=None, auto_instrument=False):
         """only used to allow the deprecated register_x library methods to still work"""
-        self._init.apply_config(None)
 
         wrapper_instance = get_instrumentation_wrapper(library_key)
         if wrapper_instance is None:

--- a/src/hypertrace/agent/__init__.py
+++ b/src/hypertrace/agent/__init__.py
@@ -59,15 +59,9 @@ class Agent:
     @contextmanager
     def edit_config(self):
         """Used by end users to modify the config"""
-        try:
-            # need to explicitly set this as None when modifying the config via code
-            # to regenerate Trace Provider with new options
-            ot._TRACER_PROVIDER = None  # pylint:disable=W0212
-            agent_config = self._config.agent_config
-            yield agent_config
-            self._config.agent_config = agent_config
-        finally:
-            self._init.apply_config(self._config)
+        agent_config = self._config.agent_config
+        yield agent_config
+        self._config.agent_config = agent_config
 
     def instrument(self, app=None, skip_libraries=None, auto_instrument=False):
         '''used to register applicable instrumentation wrappers'''
@@ -86,6 +80,8 @@ class Agent:
 
     def _instrument(self, library_key, app=None, auto_instrument=False):
         """only used to allow the deprecated register_x library methods to still work"""
+        self._init.apply_config(None)
+
         wrapper_instance = get_instrumentation_wrapper(library_key)
         if wrapper_instance is None:
             return

--- a/src/hypertrace/agent/init/__init__.py
+++ b/src/hypertrace/agent/init/__init__.py
@@ -36,15 +36,6 @@ class AgentInit:  # pylint: disable=R0902,R0903
             logger.info('Registering after_in_child handler.')
             os.register_at_fork(after_in_child=self.post_fork)  # pylint:disable=E1101
 
-        try:
-            self.apply_config(None)
-
-        except Exception as err:  # pylint: disable=W0703
-            logger.error('Failed to initialize tracer: exception=%s, stacktrace=%s',
-                         err,
-                         traceback.format_exc())
-            raise sys.exc_info()[0]
-
     def post_fork(self):
         """Used to reinitialize exporter & processors in separate worker processes"""
         self.apply_config(None)  # pylint:disable=W0212

--- a/tests/hypertrace/__init__test.py
+++ b/tests/hypertrace/__init__test.py
@@ -1,0 +1,26 @@
+from hypertrace.agent import Agent
+from hypertrace.agent.config import AgentConfig
+from hypertrace.agent.config import config_pb2 as hypertrace_config
+
+
+def test_edit_config():
+    agent = Agent()
+    with agent.edit_config() as config:
+        config.service_name = "some new service name"
+        config.reporting.endpoint = "http://localhost:4317"
+        config.reporting.trace_reporter_type = hypertrace_config.TraceReporterType.OTLP
+        config.propagation_formats = [hypertrace_config.PropagationFormat.B3]
+
+    assert agent._config.agent_config.reporting.trace_reporter_type \
+           is hypertrace_config.TraceReporterType.OTLP  # pylint:disable=W0212
+    assert agent._config.agent_config.propagation_formats == [
+        hypertrace_config.PropagationFormat.B3]  # pylint:disable=W0212
+    assert agent._config.agent_config.service_name == "some new service name"  # pylint:disable=W0212
+
+    err = None
+    try:
+        agent.instrument()
+    except Exception as e: # pylint: disable=W0703
+        err = e
+
+    assert err is None

--- a/tests/integration/autoinstrumentation/requirements.txt
+++ b/tests/integration/autoinstrumentation/requirements.txt
@@ -2,8 +2,10 @@
 google
 protobuf
 pyyaml
-flask
+flask==2.1.1
+werkzeug==2.0.3
 pytest
+psycopg2
 pytest-xdist
 mysql-connector-python==8.0.23
 

--- a/tests/integration/autoinstrumentation/requirements.txt
+++ b/tests/integration/autoinstrumentation/requirements.txt
@@ -2,7 +2,7 @@
 google
 protobuf
 pyyaml
-flask==2.1.1
+flask==2.0.3
 werkzeug==2.0.3
 pytest
 psycopg2

--- a/tests/integration/autoinstrumentation/tox.ini
+++ b/tests/integration/autoinstrumentation/tox.ini
@@ -7,7 +7,7 @@ sitepackages = True
 install_command = pip install {opts} {packages}
 
 deps =
-    -rrequirements.txt
+    -r requirements.txt
 
 whitelist_externals =
     pytest

--- a/tests/integration/gunicorn/flask_app/requirements.txt
+++ b/tests/integration/gunicorn/flask_app/requirements.txt
@@ -14,6 +14,7 @@ google
 protobuf
 pyyaml
 mysql.connector
-flask
+flask==2.1.1
+werkzeug==2.0.3
 pytest
 gunicorn

--- a/tests/integration/gunicorn/requirements.txt
+++ b/tests/integration/gunicorn/requirements.txt
@@ -3,5 +3,5 @@ google
 protobuf
 pyyaml
 mysql.connector
-flask
+flask==2.0.3
 pytest

--- a/tests/integration/gunicorn/tox.ini
+++ b/tests/integration/gunicorn/tox.ini
@@ -9,7 +9,7 @@ sitepackages = True
 
 [testenv:test_mysql_instrumentation]
 deps =
-    -rrequirements.txt
+    -r requirements.txt
 
 whitelist_externals =
     docker-compose


### PR DESCRIPTION
## Description
Attempting to re-init tracers after code based configuration changes would cause the existing tracer provider to error.  

This defers tracer initialization until the user calls instrument, allowing them to configure the agent through code.