### PR TITLE
Requests library additional request body handling

### DIFF
--- a/src/hypertrace/agent/instrumentation/requests/__init__.py
+++ b/src/hypertrace/agent/instrumentation/requests/__init__.py
@@ -22,8 +22,11 @@ def get_active_span_for_call_wrapper(requests_wrapper):
             response_content = ''
         request_content = None
         if hasattr(response.request, 'content'):
-            logger.debug('Converting request message body to string.')
+            logger.debug('Converting request message content to string.')
             request_content = response.request.content.decode()
+        elif hasattr(response.request, 'body') and hasattr(response.request.body, 'decode'):
+            logger.debug('Converting request message body to string.')
+            request_content = response.request.body.decode()
         else:
             logger.debug('No request message body. Setting to blank string.')
             request_content = ''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from opentelemetry.trace import Span
 from hypertrace.agent import Agent, _uninstrument_all
 from hypertrace.agent.filter import Filter
 from hypertrace.agent.filter.registry import Registry
-from hypertrace.agent.instrumentation import instrumentation_definitions
 from tests import configure_inmemory_span_exporter
 
 
@@ -26,7 +25,6 @@ class SampleBodyBlockingFilter(Filter):
     def evaluate_body(self, span: Span, body, headers: dict, request_type) -> bool:
         return True
 
-
 @pytest.fixture
 def agent():
     # we never want to export spans to default exporter
@@ -36,6 +34,7 @@ def agent():
     _uninstrument_all()
     Agent._instance = None
     agent = Agent()
+    agent._init.init_trace_provider()
 
     return agent
 


### PR DESCRIPTION
We should also check for `response.request.body` in addition to `.content`. 

Added unit test to verify.