### PR TITLE
handle malformed events add test

### DIFF
--- a/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
+++ b/src/hypertrace/agent/instrumentation/aws_lambda/__init__.py
@@ -50,6 +50,10 @@ class AwsLambdaInstrumentorWrapper(AwsLambdaInstrumentor, BaseInstrumentorWrappe
             )
 
             lambda_event = args[0]
+            if isinstance(lambda_event, dict) is False:
+                logger.warn("Received unexpected lambda event")
+                logger.debug("Actual lambda event", str(lambda_event))
+                return call_wrapped(*args, **kwargs)
 
 
             parent_context = aws_lambda._determine_parent_context(  # pylint:disable=W0212


### PR DESCRIPTION
## Description
In scenarios where a lambda doesn't receive an valid api gateway event we should just invoke the original, not try to parse.
